### PR TITLE
feat: v0.2.1 remaining integration tests

### DIFF
--- a/tests/integration/01-health-and-status.test.ts
+++ b/tests/integration/01-health-and-status.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Integration: Monitor worker API endpoints.
+ * Tests all GET routes: /_health, /status, /errors, /budgets, /workers
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { hasCredentials, loadTestResources, fetchWorker, type TestResources } from './helpers.js';
+
+const SKIP = !hasCredentials();
+let monitorUrl: string;
+
+beforeAll(() => {
+	if (SKIP) return;
+	const { resources } = loadTestResources();
+	monitorUrl = resources.monitorWorkerUrl;
+});
+
+describe.skipIf(SKIP)('monitor worker: API endpoints', () => {
+	it('GET /_health returns healthy', async () => {
+		const resp = await fetchWorker(monitorUrl, '/_health', { retries: 5 });
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.healthy).toBe(true);
+		expect(body.account).toBe('test-account');
+		expect(body.timestamp).toBeGreaterThan(0);
+	}, 30_000);
+
+	it('GET /status returns full status object', async () => {
+		const resp = await fetchWorker(monitorUrl, '/status');
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body).toHaveProperty('account');
+		expect(body).toHaveProperty('accountId');
+		expect(body).toHaveProperty('healthy');
+		expect(body).toHaveProperty('circuitBreaker');
+		expect(body).toHaveProperty('workers');
+		expect(body).toHaveProperty('github');
+		expect(body).toHaveProperty('slack');
+		expect(body).toHaveProperty('timestamp');
+		expect(body.timestamp).toBeGreaterThan(0);
+	}, 15_000);
+
+	it('GET /errors returns errors array', async () => {
+		const resp = await fetchWorker(monitorUrl, '/errors');
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.account).toBe('test-account');
+		expect(Array.isArray(body.errors)).toBe(true);
+		expect(typeof body.count).toBe('number');
+	}, 15_000);
+
+	it('GET /budgets returns circuit breakers array', async () => {
+		const resp = await fetchWorker(monitorUrl, '/budgets');
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.account).toBe('test-account');
+		expect(Array.isArray(body.circuitBreakers)).toBe(true);
+		expect(typeof body.count).toBe('number');
+	}, 15_000);
+
+	it('GET /workers returns workers array', async () => {
+		const resp = await fetchWorker(monitorUrl, '/workers');
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.account).toBe('test-account');
+		expect(Array.isArray(body.workers)).toBe(true);
+		expect(typeof body.count).toBe('number');
+	}, 15_000);
+});

--- a/tests/integration/02-consumer-sdk.test.ts
+++ b/tests/integration/02-consumer-sdk.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration: Consumer SDK features.
+ * Tests: health endpoint, multi-route, POST method, 404, last_seen KV.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+	hasCredentials,
+	loadTestResources,
+	fetchWorker,
+	readTestKVKey,
+	sleep,
+	type TestEnv,
+	type TestResources,
+} from './helpers.js';
+
+const SKIP = !hasCredentials();
+let env: TestEnv;
+let resources: TestResources;
+
+beforeAll(() => {
+	if (SKIP) return;
+	const loaded = loadTestResources();
+	env = loaded.env;
+	resources = loaded.resources;
+});
+
+describe.skipIf(SKIP)('consumer SDK features', () => {
+	it('SDK health endpoint at /_monitor/health', async () => {
+		const resp = await fetchWorker(resources.consumerWorkerUrl, '/_monitor/health', { retries: 5 });
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.healthy).toBe(true);
+		expect(body.worker).toBe('test-cf-monitor-consumer');
+		expect(body.bindings).toBe(true);
+	}, 30_000);
+
+	it('GET /api/test returns 200', async () => {
+		// Use retries — stale CB state from previous run may briefly cause 503
+		const resp = await fetchWorker(resources.consumerWorkerUrl, '/api/test', {
+			retries: 5, delayMs: 3000, expectStatus: 200,
+		});
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.ok).toBe(true);
+		expect(body.timestamp).toBeGreaterThan(0);
+	}, 30_000);
+
+	it('GET /api/users/123 normalises path (strips numeric segment)', async () => {
+		const resp = await fetchWorker(resources.consumerWorkerUrl, '/api/users/123');
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.ok).toBe(true);
+		expect(body.route).toBe('users');
+	}, 15_000);
+
+	it('POST /api/submit returns 200 with method', async () => {
+		const resp = await fetch(`${resources.consumerWorkerUrl}/api/submit`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ data: 'test' }),
+		});
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.ok).toBe(true);
+		expect(body.method).toBe('POST');
+	}, 15_000);
+
+	it('Unknown route returns 404', async () => {
+		const resp = await fetchWorker(resources.consumerWorkerUrl, '/nonexistent');
+		expect(resp.status).toBe(404);
+	}, 10_000);
+
+	it('SDK writes last_seen to KV after request', async () => {
+		// Make a request to trigger telemetry flush
+		await fetchWorker(resources.consumerWorkerUrl, '/api/test');
+		await sleep(5000);
+
+		// Read last_seen via KV REST API
+		const lastSeen = await readTestKVKey(
+			env,
+			resources.kvNamespaceId,
+			'workers:test-cf-monitor-consumer:last_seen'
+		);
+
+		expect(lastSeen).not.toBeNull();
+		const ts = new Date(lastSeen!);
+		expect(ts.getTime()).not.toBeNaN();
+		// Should be within last 60 seconds
+		expect(Date.now() - ts.getTime()).toBeLessThan(60_000);
+	}, 20_000);
+});

--- a/tests/integration/03-circuit-breaker.test.ts
+++ b/tests/integration/03-circuit-breaker.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration: Circuit breaker enforcement.
+ * Tests: feature CB trip/reset via worker admin endpoints, account CB.
+ *
+ * Uses POST /admin/cb/* endpoints on the MONITOR worker to trip/reset CBs.
+ * Worker-side KV writes propagate instantly to the consumer (same edge),
+ * avoiding the 30-60s KV REST API eventual consistency delay.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+	hasCredentials,
+	loadTestResources,
+	fetchWorkerPost,
+	waitForConsumerStatus,
+	sleep,
+	type TestEnv,
+	type TestResources,
+} from './helpers.js';
+
+const SKIP = !hasCredentials();
+let env: TestEnv;
+let resources: TestResources;
+
+const TEST_FEATURE = 'test-cf-monitor-consumer:fetch:GET:api-test';
+
+beforeAll(() => {
+	if (SKIP) return;
+	const loaded = loadTestResources();
+	env = loaded.env;
+	resources = loaded.resources;
+});
+
+// Clean up ALL CB state after this file completes
+afterAll(async () => {
+	if (SKIP) return;
+	try {
+		await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cb/reset', { featureId: TEST_FEATURE });
+		await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cb/account', { status: 'clear' });
+	} catch {
+		// Best effort
+	}
+});
+
+describe.skipIf(SKIP)('circuit breaker: feature-level', () => {
+	it('trip (STOP) returns 503 from consumer', async () => {
+		// Trip CB via monitor worker admin endpoint (worker-side KV write)
+		const tripResp = await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cb/trip', {
+			featureId: TEST_FEATURE,
+			reason: 'integration-test',
+			ttlSeconds: 300,
+		});
+		expect(tripResp.status).toBe(200);
+
+		// Worker-side write should propagate within seconds
+		await sleep(2000);
+
+		const resp = await waitForConsumerStatus(
+			resources.consumerWorkerUrl, '/api/test', 503, 30_000
+		);
+		expect(resp.status).toBe(503);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.error).toBe('Feature temporarily unavailable');
+	}, 45_000);
+
+	it('reset (GO) restores consumer to 200', async () => {
+		// Reset CB via monitor worker admin endpoint
+		const resetResp = await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cb/reset', {
+			featureId: TEST_FEATURE,
+		});
+		expect(resetResp.status).toBe(200);
+
+		await sleep(2000);
+
+		const resp = await waitForConsumerStatus(
+			resources.consumerWorkerUrl, '/api/test', 200, 30_000
+		);
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as Record<string, unknown>;
+		expect(body.ok).toBe(true);
+	}, 45_000);
+});
+
+describe.skipIf(SKIP)('circuit breaker: account-level', () => {
+	// Ensure clean state before account tests
+	beforeAll(async () => {
+		await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cb/reset', { featureId: TEST_FEATURE });
+		await sleep(2000);
+		await waitForConsumerStatus(resources.consumerWorkerUrl, '/api/test', 200, 20_000);
+	}, 30_000);
+
+	it('account paused returns 503', async () => {
+		const pauseResp = await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cb/account', {
+			status: 'paused',
+			ttlSeconds: 300,
+		});
+		expect(pauseResp.status).toBe(200);
+
+		await sleep(2000);
+
+		const resp = await waitForConsumerStatus(
+			resources.consumerWorkerUrl, '/api/test', 503, 30_000
+		);
+		expect(resp.status).toBe(503);
+	}, 45_000);
+
+	it('account CB cleared restores service', async () => {
+		const clearResp = await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cb/account', {
+			status: 'clear',
+		});
+		expect(clearResp.status).toBe(200);
+
+		await sleep(2000);
+
+		const resp = await waitForConsumerStatus(
+			resources.consumerWorkerUrl, '/api/test', 200, 30_000
+		);
+		expect(resp.status).toBe(200);
+	}, 45_000);
+});

--- a/tests/integration/06-budget-enforcement.test.ts
+++ b/tests/integration/06-budget-enforcement.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration: Budget enforcement pipeline.
+ * Tests: seed budget config → seed exceeded usage → trigger budget-check cron → CB trips.
+ * Safety: No SLACK_WEBHOOK_URL on test worker → no Slack spam. Test KV namespace → no production impact.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+	hasCredentials,
+	loadTestResources,
+	writeTestKVKey,
+	readTestKVKey,
+	deleteTestKVKey,
+	fetchWorkerPost,
+	sleep,
+	type TestEnv,
+	type TestResources,
+} from './helpers.js';
+
+const SKIP = !hasCredentials();
+let env: TestEnv;
+let resources: TestResources;
+
+const TEST_FEATURE = 'test-budget-feature:fetch:GET:test';
+const BUDGET_CONFIG_KEY = `budget:config:${TEST_FEATURE}`;
+const CB_KEY = `cb:v1:feature:${TEST_FEATURE}`;
+
+beforeAll(() => {
+	if (SKIP) return;
+	const loaded = loadTestResources();
+	env = loaded.env;
+	resources = loaded.resources;
+});
+
+// Always clean up budget test data
+afterAll(async () => {
+	if (SKIP) return;
+	try {
+		const today = new Date().toISOString().slice(0, 10);
+		await Promise.all([
+			deleteTestKVKey(env, resources.kvNamespaceId, BUDGET_CONFIG_KEY),
+			deleteTestKVKey(env, resources.kvNamespaceId, `budget:usage:daily:${TEST_FEATURE}:${today}`),
+			deleteTestKVKey(env, resources.kvNamespaceId, CB_KEY),
+			deleteTestKVKey(env, resources.kvNamespaceId, `${CB_KEY}:reason`),
+		]);
+	} catch {
+		// Best effort cleanup
+	}
+});
+
+describe.skipIf(SKIP)('budget enforcement: seed → cron → CB trip', () => {
+	it('seed budget config and exceeded usage in KV', async () => {
+		const today = new Date().toISOString().slice(0, 10);
+
+		// Set a very low budget limit
+		await writeTestKVKey(env, resources.kvNamespaceId, BUDGET_CONFIG_KEY, JSON.stringify({
+			kv_reads: 5,
+		}));
+
+		// Set usage that exceeds the limit
+		await writeTestKVKey(env, resources.kvNamespaceId,
+			`budget:usage:daily:${TEST_FEATURE}:${today}`,
+			JSON.stringify({ kv_reads: 10 })
+		);
+
+		// Wait for KV propagation
+		await sleep(5000);
+
+		// Verify seeds are readable
+		const config = await readTestKVKey(env, resources.kvNamespaceId, BUDGET_CONFIG_KEY);
+		expect(config).not.toBeNull();
+	}, 20_000);
+
+	it('budget-check cron trips CB for exceeded feature', async () => {
+		// Trigger the budget-check cron via admin endpoint
+		const resp = await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cron/budget-check', {});
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as { ok: boolean; cron: string };
+		expect(body.ok).toBe(true);
+		expect(body.cron).toBe('budget-check');
+
+		// Wait for KV writes from the cron
+		await sleep(5000);
+
+		// Verify CB was tripped
+		const cbValue = await readTestKVKey(env, resources.kvNamespaceId, CB_KEY);
+		expect(cbValue).toBe('STOP');
+	}, 30_000);
+
+	it('cleanup: reset CB via worker admin endpoint', async () => {
+		// Use worker-side reset (instant propagation) instead of REST API write
+		const resp = await fetchWorkerPost(resources.monitorWorkerUrl, '/admin/cb/reset', {
+			featureId: TEST_FEATURE,
+		});
+		expect(resp.status).toBe(200);
+
+		const body = await resp.json() as { ok: boolean; action: string };
+		expect(body.ok).toBe(true);
+		expect(body.action).toBe('reset');
+	}, 15_000);
+});


### PR DESCRIPTION
## Summary
- Add 4 integration test files that were locally present but untracked (01-health, 02-consumer-sdk, 03-circuit-breaker, 06-budget-enforcement)
- These complete the integration test suite alongside the 6 files already committed in previous PRs
- Total integration coverage: 53 tests across 10 files

## Test plan
- [ ] CI passes (typecheck Node 20+22, unit tests, coverage, publint, attw, package validation)
- [ ] All 222 unit tests pass
- [ ] Package size under 200kB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>