### PR TITLE
fix: v0.3.1 GraphQL usage collection bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,22 @@
 
 All notable changes to cf-monitor are documented here. This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
+## [0.3.1] - 2026-03-22
+
+### Fixed
+- Wrong GraphQL dataset names for usage collection — `d1AnalyticsAdaptive` corrected to `d1AnalyticsAdaptiveGroups`, removed 4 non-existent datasets (AI Gateway, Vectorize, Queues) (#57)
+- D1 GraphQL dataset requires `date_geq`/`date_leq` filters (YYYY-MM-DD), not `datetime_geq` (ISO 8601) — caused entire query to fail (#58)
+- Single GraphQL query failure killed all service results — split into 5 parallel per-service queries for isolation (#59)
+
+### Changed
+- Account usage collection now queries 5 CF services with GraphQL datasets (Workers, D1, KV, R2, Durable Objects). AI Gateway, Vectorize, and Queues do not have GraphQL Analytics datasets — may be added via REST APIs later.
+
 ## [0.3.0] - 2026-03-22
 
 ### Added
 - **Plan detection** (#53): Auto-detects Workers Free vs Paid plan via CF Subscriptions API. Budget auto-seeding now selects correct defaults for each plan. CLI `status` and `GET /status` show detected plan.
 - **Billing-period-aware budgets** (#54): Monthly budget tracking aligned to actual CF billing cycle (not calendar month). Gradual migration — old keys expire via TTL, both formats checked during transition.
-- **Account-wide usage collection** (#55): Hourly GraphQL queries for 9 CF services (D1, KV, R2, Workers, Workers AI, AI Gateway, Durable Objects, Vectorize, Queues). New `GET /usage` endpoint and `npx cf-monitor usage` CLI command.
+- **Account-wide usage collection** (#55): Hourly GraphQL queries for 5 CF services (D1, KV, R2, Workers, Durable Objects). New `GET /usage` endpoint and `npx cf-monitor usage` CLI command.
 - New `GET /plan` endpoint — returns detected plan type, billing period, days remaining, and plan allowances
 - New `GET /usage` endpoint — returns per-service usage with plan context and data accuracy disclaimer
 - New `npx cf-monitor usage` CLI command — formatted table with colour-coded % of plan used
@@ -102,6 +112,7 @@ All notable changes to cf-monitor are documented here. This project follows [Kee
 - CI pipeline: Node 20/22 matrix, publint, attw, lockfile-lint, package validation
 - Release workflow: tag-triggered npm publish
 
+[0.3.1]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/littlebearapps/cf-monitor/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/littlebearapps/cf-monitor/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/littlebearapps/cf-monitor/compare/v0.2.0...v0.2.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@
 | **Language** | TypeScript |
 | **Runtime** | Cloudflare Workers |
 | **npm** | `@littlebearapps/cf-monitor` |
-| **Status** | v0.3.0 — production-tested, published to npm |
+| **Status** | v0.3.1 — production-tested, published to npm |
 | **Repository** | https://github.com/littlebearapps/cf-monitor |
 | **Licence** | MIT |
 | **Issues** | https://github.com/littlebearapps/cf-monitor/issues |
@@ -237,7 +237,15 @@ Deployed 2026-03-21 on Platform CF account (`55a0bf6d...`):
 
 **#54 — Billing-period-aware budgets**: Monthly KV keys transition from `YYYY-MM` to `YYYY-MM-DD` (billing period start). Billing period cached in KV (32d TTL). `checkMonthlyBudgets()` checks both old and new key formats during transition (sums usage). SDK-side module-level cache (1hr TTL per isolate) avoids per-invocation KV reads. `GET /budgets` includes `billingPeriod`. Falls back to calendar month if unavailable.
 
-**#55 — Account-wide usage collection**: Hourly `collect-account-usage` cron queries CF GraphQL for 9 services (D1, KV, R2, Workers, AI Gateway, DO, Vectorize, Queues). Daily snapshots stored in KV (`usage:account:{date}`, 32d TTL). New `GET /usage` endpoint with plan context + disclaimer. New `npx cf-monitor usage` CLI. Uses existing `CLOUDFLARE_API_TOKEN` — no new token needed. Data is approximate per CF documentation.
+**#55 — Account-wide usage collection**: Hourly `collect-account-usage` cron queries CF GraphQL for 5 services (Workers, D1, KV, R2, Durable Objects). Daily snapshots stored in KV (`usage:account:{date}`, 32d TTL). New `GET /usage` endpoint with plan context + disclaimer. New `npx cf-monitor usage` CLI. Uses existing `CLOUDFLARE_API_TOKEN` — no new token needed. Data is approximate per CF documentation. AI Gateway, Vectorize, and Queues do not have GraphQL Analytics datasets — may be added via REST APIs later.
+
+## Bug Fixes (v0.3.1)
+
+**#57 — Wrong GraphQL dataset names**: FIXED. `d1AnalyticsAdaptive` corrected to `d1AnalyticsAdaptiveGroups`. Removed 4 non-existent datasets (AI Gateway, Vectorize, Queues producer/consumer) — these services don't have GraphQL Analytics datasets. Service count corrected from 9 to 5.
+
+**#58 — D1 date filter format**: FIXED. D1's `d1AnalyticsAdaptiveGroups` requires `date_geq`/`date_leq` (YYYY-MM-DD), not `datetime_geq` (ISO 8601). Caused entire batched GraphQL query to fail with "unknown arg datetime_geq".
+
+**#59 — Single query kills all results**: FIXED. Split core services into 5 parallel GraphQL queries (Workers, D1, KV, R2, DO). Each individually try-caught. If one service query fails, the others still return data. Costs 5 requests instead of 2 but well within CF's 25/5min rate limit.
 
 ## Bug Fixes (v0.2.2)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/cf-monitor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Self-contained Cloudflare account monitoring: error collection, feature budgets, circuit breakers, cost protection. One worker per account.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,7 +30,7 @@ const program = new Command();
 program
 	.name('cf-monitor')
 	.description('Self-contained Cloudflare account monitoring')
-	.version('0.3.0');
+	.version('0.3.1');
 
 program
 	.command('init')


### PR DESCRIPTION
## Summary

Patch release documenting and versioning 3 production bugs found during v0.3.0 deployment:

- **#57**: Wrong GraphQL dataset names — `d1AnalyticsAdaptive` corrected to `d1AnalyticsAdaptiveGroups`, removed 4 non-existent datasets. Service count 9→5.
- **#58**: D1 requires `date_geq`/`date_leq` (YYYY-MM-DD), not `datetime_geq` (ISO 8601). Caused entire query to fail.
- **#59**: Single GraphQL query failure killed all results. Split into 5 parallel per-service queries.

Code fixes were already committed to main (93867e4, 4c93204, d83717b). This PR adds version bump (0.3.0→0.3.1), changelog, and CLAUDE.md updates.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 254 tests pass
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)