### PR TITLE
feat(security): v0.3.3 security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to cf-monitor are documented here. This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
+## [0.3.3] - 2026-03-22
+
+### Security
+- Admin endpoint authentication: all `/admin/*` POST routes require `Authorization: Bearer <ADMIN_TOKEN>` with timing-safe comparison (#62)
+- CLI command injection: `execSync` replaced with `execFileSync` in `secret.ts`, `deploy.ts`, `upgrade.ts`; secret name validation added (#63)
+- Markdown escaping: `escapeMd()` helper sanitises GitHub issue table cells, preventing injection via crafted error messages (#64)
+- GraphQL input validation: `CF_ACCOUNT_ID` validated against `/^[0-9a-f]{32}$/i` before query interpolation (#65)
+- Symbol privacy: `Symbol.for()` changed to `Symbol()` for module-private tracking metadata (#67)
+- Info disclosure reduction: `/status` endpoint no longer returns `accountId`, worker `names`, `billingPeriod`, or `github.repo` (#68)
+- Webhook replay protection: `X-GitHub-Delivery` nonce stored in KV (24hr TTL), duplicate deliveries silently dropped (#69)
+- Error response hardening: admin endpoints return generic `'Internal error'` instead of `String(err)` (#70)
+- KV TOCTOU race in budget accumulation documented as known limitation (#66)
+
+### Added
+- `docs/security.md` — comprehensive security guide: admin auth, secrets management, threat model, data exposure, SDK security, npm package security
+- `ADMIN_TOKEN` environment variable for admin endpoint authentication
+- New KV prefix: `webhook:nonce:` for webhook replay protection
+
+### Changed
+- CLI `secret` subcommand syntax fixed across all documentation (`secret` → `secret set`)
+- All admin endpoint curl examples in docs now include `Authorization: Bearer` header
+- `docs/getting-started.md` — added Step 8 (admin endpoint security), GitHub PAT scope guidance
+- `docs/troubleshooting.md` — added "Admin endpoints returning 401" and "Self-monitoring shows stale crons" sections
+- `docs/configuration.md` — expanded secrets section with all 6 secrets and minimum scopes
+- `README.md` — added Security doc link, ADMIN_TOKEN requirement, admin auth notes on endpoint table
+
 ## [0.3.2] - 2026-03-22
 
 ### Added
@@ -123,6 +149,7 @@ All notable changes to cf-monitor are documented here. This project follows [Kee
 - CI pipeline: Node 20/22 matrix, publint, attw, lockfile-lint, package validation
 - Release workflow: tag-triggered npm publish
 
+[0.3.3]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/littlebearapps/cf-monitor/compare/v0.2.2...v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,20 @@ Deployed 2026-03-21 on Platform CF account (`55a0bf6d...`):
 
 **#44 — Self-monitoring**: cf-monitor now tracks its own handler execution, errors, and cron staleness. New `self-monitor.ts` module provides fail-open recording functions. All 3 handlers (tail, scheduled, fetch) are instrumented. New `GET /self-health` endpoint returns handler status, error counts, and stale cron detection (200 when healthy, 503 when stale). Staleness alerts via Slack (1/day dedup). Self-telemetry written to AE (`blob2` format: `self:{durationMs}:{1|0}`, `doubles[0]=1`). New KV prefixes: `self:v1:cron:last_run` (handler timestamps as single JSON blob), `self:v1:error:{handler}:{date}` (error counts), `self:v1:errors:count:{date}` (daily total). `CRON_HANDLER_REGISTRY` constant for staleness thresholds. Admin cron trigger: `POST /admin/cron/staleness-check`. Phase 3 (self-capture via error pipeline) deferred to future version.
 
+## v0.3.3 Security Hardening
+
+Full security audit with 9 fixes:
+
+- **Admin endpoint auth**: All `/admin/*` POST routes require `Authorization: Bearer <ADMIN_TOKEN>` (timing-safe comparison). New `ADMIN_TOKEN` env var in `MonitorWorkerEnv`.
+- **CLI command injection**: `execSync` → `execFileSync` in `secret.ts`, `deploy.ts`, `upgrade.ts`. Secret name validation: `/^[A-Z_][A-Z0-9_]*$/`.
+- **Markdown escaping**: `escapeMd()` helper sanitises table cell values in GitHub issue bodies (`github.ts`, `fetch-handler.ts`).
+- **Webhook replay protection**: `X-GitHub-Delivery` nonce stored in KV (24hr TTL). Duplicate deliveries silently dropped.
+- **GraphQL input validation**: `CF_ACCOUNT_ID` validated against `/^[0-9a-f]{32}$/i` before interpolation in `collect-account-usage.ts` and `collect-metrics.ts`.
+- **Symbol privacy**: `Symbol.for('cf-monitor:tracked')` → `Symbol('cf-monitor:tracked')` (module-private, undiscoverable by other code in isolate).
+- **Info disclosure reduction**: `/status` no longer returns `accountId`, worker `names`, `billingPeriod`, or `github.repo`.
+- **Error response hardening**: Admin endpoint errors return `'Internal error'` instead of `String(err)` (prevents stack trace leakage).
+- **New `docs/security.md`**: Public-facing security guide covering admin auth, secrets, threat model, data exposure, SDK security, npm package security.
+
 ## Bug Fixes (v0.2.2)
 
 **#46 — Gatus heartbeat unreachable**: FIXED. Scheduled handler's cron branches all returned before heartbeat code. Restructured to `if`/`else if` chain without early returns. Heartbeat now always fires with `success` status reflecting cron handler results.

--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ The monitor worker exposes these endpoints:
 | GET | `/usage` | Account-wide per-service usage with plan context (approximate) |
 | GET | `/self-health` | Self-monitoring status: stale crons, error counts, handler breakdown |
 | POST | `/webhooks/github` | GitHub webhook receiver (issue close/reopen/mute sync) |
-| POST | `/admin/cron/{name}` | Manually trigger any cron (for testing) |
-| POST | `/admin/cb/trip` | Trip a feature circuit breaker |
-| POST | `/admin/cb/reset` | Reset a feature circuit breaker |
-| POST | `/admin/cb/account` | Set account-level CB status |
+| POST | `/admin/cron/{name}` | Manually trigger any cron (requires `ADMIN_TOKEN`) |
+| POST | `/admin/cb/trip` | Trip a feature circuit breaker (requires `ADMIN_TOKEN`) |
+| POST | `/admin/cb/reset` | Reset a feature circuit breaker (requires `ADMIN_TOKEN`) |
+| POST | `/admin/cb/account` | Set account-level CB status (requires `ADMIN_TOKEN`) |
 
 ## ⚙️ Configuration
 
@@ -260,6 +260,7 @@ alerts:
   - Account Analytics: Read
   - Workers Scripts: Edit
   - *Optional*: Account Settings: Read (for automatic plan detection)
+- **`ADMIN_TOKEN` secret** (recommended for production — protects admin endpoints). See [Security](./docs/security.md)
 
 ## 🔄 Upgrading
 
@@ -341,8 +342,9 @@ See the [full migration guide](./docs/how-to/migrate-from-platform-sdk.md) for d
 - [Custom feature IDs](./docs/how-to/custom-feature-ids.md) — featureId, featurePrefix, features map
 - [Migrate from platform-sdk](./docs/how-to/migrate-from-platform-sdk.md) — expanded migration guide
 
-### Reference
+### Security & Reference
 
+- [Security](./docs/security.md) — admin auth, secrets, threat model, data exposure
 - [Troubleshooting](./docs/troubleshooting.md) — common issues with solutions
 - [Changelog](./CHANGELOG.md) — version history
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,10 +227,15 @@ alerts:
 Set secrets on the deployed worker:
 
 ```bash
-npx cf-monitor secret GITHUB_TOKEN
-npx cf-monitor secret SLACK_WEBHOOK_URL
-npx cf-monitor secret GITHUB_WEBHOOK_SECRET
+npx cf-monitor secret set CLOUDFLARE_API_TOKEN    # Required — GraphQL, discovery, plan detection
+npx cf-monitor secret set ADMIN_TOKEN              # Recommended — protects /admin/* endpoints
+npx cf-monitor secret set GITHUB_TOKEN             # Optional — error issue creation
+npx cf-monitor secret set SLACK_WEBHOOK_URL        # Optional — budget/error alerts
+npx cf-monitor secret set GITHUB_WEBHOOK_SECRET    # Optional — webhook signature verification
+npx cf-monitor secret set GATUS_TOKEN              # Optional — heartbeat auth
 ```
+
+See [Security — Secrets management](./security.md#secrets-management) for minimum scopes and permissions.
 
 ## JSON Schema Validation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -157,16 +157,16 @@ GET https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/workers
 Set the GitHub token as a secret:
 
 ```bash
-npx cf-monitor secret GITHUB_TOKEN
+npx cf-monitor secret set GITHUB_TOKEN
 # Paste your token when prompted
 ```
 
-The token needs `repo` scope (classic) or `issues: write` permission (fine-grained).
+The token needs `issues: write` permission (fine-grained PAT, recommended) or `repo` scope (classic PAT). See [Security — GitHub PAT minimum scopes](./security.md#github-pat-minimum-scopes) for details.
 
 ### Slack Alerts
 
 ```bash
-npx cf-monitor secret SLACK_WEBHOOK_URL
+npx cf-monitor secret set SLACK_WEBHOOK_URL
 # Paste your Slack incoming webhook URL
 ```
 
@@ -174,14 +174,36 @@ npx cf-monitor secret SLACK_WEBHOOK_URL
 
 To sync issue close/reopen/mute events back to cf-monitor:
 
-1. Set the webhook secret: `npx cf-monitor secret GITHUB_WEBHOOK_SECRET`
+1. Set the webhook secret: `npx cf-monitor secret set GITHUB_WEBHOOK_SECRET`
 2. In your GitHub repo, go to Settings > Webhooks > Add webhook
 3. Payload URL: `https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/webhooks/github`
 4. Content type: `application/json`
 5. Secret: the same value you set above
 6. Events: select "Issues"
 
-## Step 8: Check account usage (optional)
+## Step 8: Secure admin endpoints (recommended)
+
+The cf-monitor worker has admin endpoints for manually triggering crons and controlling circuit breakers. These require an `ADMIN_TOKEN` secret:
+
+```bash
+# Generate a random token
+openssl rand -hex 32
+
+# Set it on the cf-monitor worker
+npx cf-monitor secret set ADMIN_TOKEN
+# Paste the token when prompted
+```
+
+Once set, admin requests must include the token:
+
+```bash
+curl -X POST https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/admin/cron/budget-check \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
+```
+
+Without `ADMIN_TOKEN`, admin endpoints return `401 Unauthorized`. See [Security — Admin endpoint authentication](./security.md#admin-endpoint-authentication) for full details.
+
+## Step 9: Check account usage (optional)
 
 After the first hourly cron runs (~up to 60 minutes after deploy), check your account-wide CF service usage:
 
@@ -194,7 +216,8 @@ This shows per-service usage (D1, KV, R2, Workers, AI, etc.) vs your plan's incl
 You can also trigger usage collection immediately:
 
 ```bash
-curl -X POST https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/admin/cron/collect-account-usage
+curl -X POST https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/admin/cron/collect-account-usage \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
 ```
 
 Or query the API:
@@ -211,4 +234,5 @@ GET https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/usage
 - [Error Collection](./guides/error-collection.md) — how fingerprinting and GitHub issues work
 - [Budgets & Circuit Breakers](./guides/budgets-and-circuit-breakers.md) — per-invocation limits and budget enforcement
 - [Cost Protection](./guides/cost-protection.md) — how cf-monitor prevents billing surprises
+- [Security](./security.md) — admin auth, secrets, threat model
 - [Troubleshooting](./troubleshooting.md) — common issues and solutions

--- a/docs/guides/slack-alerts.md
+++ b/docs/guides/slack-alerts.md
@@ -8,7 +8,7 @@ cf-monitor sends Slack alerts for budget warnings, errors, gap detections, cost 
 2. Set it as a secret on the cf-monitor worker:
 
 ```bash
-npx cf-monitor secret SLACK_WEBHOOK_URL
+npx cf-monitor secret set SLACK_WEBHOOK_URL
 # Paste your webhook URL when prompted
 ```
 

--- a/docs/how-to/github-webhooks.md
+++ b/docs/how-to/github-webhooks.md
@@ -17,7 +17,7 @@ This means you can manage error tracking through GitHub's normal issue workflow.
 ### Step 1: Generate a webhook secret
 
 ```bash
-npx cf-monitor secret GITHUB_WEBHOOK_SECRET
+npx cf-monitor secret set GITHUB_WEBHOOK_SECRET
 # Enter a random string (e.g. generate with: openssl rand -hex 32)
 ```
 
@@ -73,7 +73,7 @@ To unmute: remove the `cf:muted` label and reopen the issue.
 
 ## Troubleshooting
 
-**Webhook deliveries showing errors**: Check that `GITHUB_WEBHOOK_SECRET` matches exactly between GitHub and cf-monitor. Re-set with `npx cf-monitor secret GITHUB_WEBHOOK_SECRET`.
+**Webhook deliveries showing errors**: Check that `GITHUB_WEBHOOK_SECRET` matches exactly between GitHub and cf-monitor. Re-set with `npx cf-monitor secret set GITHUB_WEBHOOK_SECRET`.
 
 **Issues not syncing**: Verify the webhook is configured for "Issues" events (not "Issue comments" or other types).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,196 @@
+# Security
+
+This guide covers cf-monitor's security model, how secrets are managed, and what protections are in place.
+
+## Security model
+
+cf-monitor is a **cost protection and observability tool**, not a security product. It protects your Cloudflare bill by tracking binding operations and tripping circuit breakers when budgets are exceeded. It does not provide WAF, DDoS protection, authentication, or access control for your application workers.
+
+**Threat model**: cf-monitor defends against accidental cost overruns (infinite loops, misconfigured crons, deployment bugs). The January 2026 incident that inspired cf-monitor was caused by a worker bug writing 4.8 billion D1 rows — not by a malicious actor.
+
+## Admin endpoint authentication
+
+The cf-monitor worker exposes `/admin/*` POST endpoints for operational tasks: manually triggering crons, tripping/resetting circuit breakers, and running dry-run tests. These endpoints are protected by a shared secret (`ADMIN_TOKEN`).
+
+### What ADMIN_TOKEN protects
+
+| Endpoint | What it does |
+|----------|-------------|
+| `POST /admin/cron/{name}` | Manually trigger any cron handler |
+| `POST /admin/cb/trip` | Trip a circuit breaker on any feature |
+| `POST /admin/cb/reset` | Reset a tripped circuit breaker |
+| `POST /admin/cb/account` | Pause/unpause the entire account |
+| `POST /admin/test/github-dry-run` | Test GitHub issue formatting |
+| `POST /admin/test/slack-dry-run` | Test Slack alert formatting |
+
+Without `ADMIN_TOKEN`, these endpoints return `401 Unauthorized`. An attacker who discovers your `cf-monitor.*.workers.dev` URL cannot trip circuit breakers (DoS) or reset them (bypass cost protection).
+
+### Setting up ADMIN_TOKEN
+
+Generate a random token and set it as a Worker secret:
+
+```bash
+# Generate a 32-byte random token
+openssl rand -hex 32
+
+# Set it on the cf-monitor worker
+npx cf-monitor secret set ADMIN_TOKEN
+# Paste the token when prompted
+```
+
+Then include it in requests to admin endpoints:
+
+```bash
+curl -X POST https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/admin/cron/budget-check \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
+```
+
+### What ADMIN_TOKEN is NOT
+
+- It is **not** a Cloudflare API token — it's a simple shared secret you generate yourself
+- It is **not** required for the SDK wrapper (`monitor()`) or consumer workers — only for admin endpoints on the cf-monitor worker
+- It is **not** used for GET endpoints (`/status`, `/errors`, `/budgets`, etc.) — those are read-only and publicly accessible
+
+## Secrets management
+
+cf-monitor uses up to 6 secrets, all set via `npx cf-monitor secret set <NAME>`:
+
+| Secret | Required | Purpose | Minimum scope |
+|--------|----------|---------|---------------|
+| `CLOUDFLARE_API_TOKEN` | Yes | GraphQL metrics, worker discovery, plan detection | Workers KV Storage: Edit, Account Analytics: Read, Workers Scripts: Edit. Optional: Account Settings: Read (for plan detection) |
+| `ADMIN_TOKEN` | Recommended | Admin endpoint authentication | N/A — self-generated random string |
+| `GITHUB_TOKEN` | Optional | Create issues for captured errors | Fine-grained PAT with `issues: write` on the target repo. Classic PATs need `public_repo` (public) or `repo` (private). **Do not use full `repo` scope if `issues: write` suffices.** |
+| `SLACK_WEBHOOK_URL` | Optional | Budget warnings, error alerts, gap alerts | N/A — Slack incoming webhook URL |
+| `GITHUB_WEBHOOK_SECRET` | Optional | Verify GitHub webhook signatures | N/A — self-generated random string, must match the webhook config in GitHub |
+| `GATUS_TOKEN` | Optional | Bearer token for Gatus heartbeat pings | N/A — provided by your Gatus instance |
+
+### GitHub PAT minimum scopes
+
+For **fine-grained personal access tokens** (recommended):
+- Repository access: select only the repo(s) where you want error issues
+- Permissions: `Issues: Read and write` — nothing else needed
+
+For **classic personal access tokens**:
+- Public repos: `public_repo` scope
+- Private repos: `repo` scope (broader than needed, but the only option with classic PATs)
+
+cf-monitor creates issues, adds labels, and reads issue bodies. It does not need code access, PR permissions, or admin access.
+
+## Webhook security
+
+### HMAC-SHA256 verification
+
+The `POST /webhooks/github` endpoint verifies GitHub webhook signatures using HMAC-SHA256 with timing-safe comparison. Requests without a valid `X-Hub-Signature-256` header are rejected with `401`.
+
+### Replay protection
+
+Each webhook delivery includes a unique `X-GitHub-Delivery` header (a UUID). cf-monitor stores this as a KV nonce with a 24-hour TTL. Replayed webhooks within 24 hours are silently dropped. This prevents an attacker who captures a valid webhook payload from replaying it to manipulate error fingerprint state.
+
+## Data exposure
+
+### Unauthenticated GET endpoints
+
+These endpoints are publicly accessible (no auth required):
+
+| Endpoint | Data exposed | Data NOT exposed |
+|----------|-------------|-----------------|
+| `GET /_health` | Account name, healthy status | Account ID, worker names |
+| `GET /status` | Account name, plan type, healthy status, CB states, worker count | Account ID, worker names, billing period, GitHub repo |
+| `GET /errors` | Error fingerprints, GitHub issue URLs | Error messages, stack traces |
+| `GET /budgets` | Active circuit breakers by feature ID | Budget limits, usage numbers |
+| `GET /workers` | Worker names and count | Worker code, bindings |
+| `GET /plan` | Plan type, billing period, allowances | Account ID |
+| `GET /usage` | Per-service usage numbers | Account ID |
+| `GET /self-health` | Handler status, error counts, stale crons | Internal state |
+
+The `/status` endpoint intentionally omits the Cloudflare account ID, individual worker names, and GitHub repo path to reduce reconnaissance value.
+
+### Consumer worker health endpoint
+
+Each worker wrapped with `monitor()` exposes `/_monitor/health` (configurable). This returns the worker name, binding status, and circuit breaker state. It does not return the account ID or binding details.
+
+## SDK security
+
+### Fail-open design
+
+All SDK code fails open by default. If KV is unreachable, AE writes fail, or any internal error occurs, the consumer worker's response is not affected. Monitoring should never be the thing that breaks production.
+
+### Binding proxy isolation
+
+cf-monitor's own KV and AE bindings (`CF_MONITOR_KV`, `CF_MONITOR_AE`) are excluded from proxy wrapping. The SDK never tracks its own operations, preventing feedback loops.
+
+### Path normalisation
+
+Auto-generated feature IDs strip sensitive content from URL paths:
+- Numeric segments (`/users/123` becomes `users`)
+- UUIDs
+- MongoDB-style hex IDs (24+ characters)
+- Query strings (stripped entirely)
+- Paths limited to 2 segments
+
+This prevents sensitive data (user IDs, tokens in paths) from appearing in feature IDs, KV keys, or AE data.
+
+### Module-private symbol
+
+The internal tracking metadata (metrics, feature ID, worker name) is stored on the env proxy using a module-private `Symbol()`. This is not discoverable by other code in the isolate, preventing malicious npm dependencies from reading internal metrics or worker names.
+
+## Error message handling
+
+### Truncation
+
+Error messages from tail events are truncated to **500 characters** before storage or transmission. This limits the blast radius if error messages contain sensitive data.
+
+### Markdown escaping
+
+Error data interpolated into GitHub issue table cells is escaped to prevent markdown injection. Characters like `|`, backticks, brackets, and exclamation marks are backslash-escaped, preventing an attacker from injecting tracking images, phishing links, or @mentions via crafted `console.error()` messages.
+
+### Fingerprint normalisation
+
+The error fingerprint algorithm normalises messages by replacing:
+- UUIDs with `<UUID>`
+- Hex IDs (24+ chars) with `<ID>`
+- Numbers (4+ digits) with `<N>`
+- Timestamps with `<TS>`
+- IP addresses with `<IP>`
+
+This ensures the same logical error produces the same fingerprint regardless of variable content, and that fingerprints don't contain PII.
+
+## npm package security
+
+| Check | Status |
+|-------|--------|
+| **`files` allowlist** | Only `src/`, `dist/cli/`, `worker/`, and `cf-monitor.schema.json` are published |
+| **`.npmignore`** | Excludes `tests/`, `.cf-monitor/`, `.wrangler/`, `.dev.vars`, `.github/` |
+| **No postinstall scripts** | Only `prepublishOnly: build:cli` (runs before publish, not on install) |
+| **Runtime dependencies** | 2: `commander` (CLI framework), `picocolors` (terminal colours). Both well-maintained, no known CVEs |
+| **No dynamic code execution** | Zero use of `Function()` constructors or dynamic code generation anywhere in the codebase |
+| **No `any` types** | SDK code uses `unknown` with explicit narrowing throughout |
+
+## CLI security
+
+### Input validation
+
+The `secret set` command validates secret names against `/^[A-Z_][A-Z0-9_]*$/` to prevent shell metacharacter injection. All CLI commands that invoke wrangler use `execFileSync` (array arguments, no shell interpolation).
+
+### Token handling
+
+The `--api-token` CLI flag passes the token to wrangler as a command-line argument. On multi-user systems, this may be visible in process listings. Prefer environment variables (`CLOUDFLARE_API_TOKEN`) or `wrangler login` for authentication.
+
+## Known limitations
+
+### KV budget accumulation race condition
+
+Budget counters in KV use a read-modify-write pattern without atomicity (KV does not support atomic increment). Under high concurrency, usage may be slightly under-counted. This is mitigated by the hourly budget enforcement cron, which recalculates from Analytics Engine as the authoritative source.
+
+### 32-bit fingerprint hash
+
+Error fingerprinting uses FNV-1a 32-bit, which has a ~50% collision probability at ~77K unique errors. In practice, most accounts see far fewer unique errors. If collisions become an issue, a future version may upgrade to SHA-256.
+
+## Reporting vulnerabilities
+
+If you discover a security vulnerability in cf-monitor, please report it responsibly:
+
+- **Email**: security@littlebearapps.com
+- **GitHub**: [Create a private security advisory](https://github.com/littlebearapps/cf-monitor/security/advisories/new)
+
+Please do not open public issues for security vulnerabilities.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,6 +41,7 @@ Common issues and their solutions when using cf-monitor.
 2. **Manual reset** — force a reset via the admin endpoint:
    ```bash
    curl -X POST https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/admin/cb/reset \
+     -H "Authorization: Bearer YOUR_ADMIN_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"featureId": "your-feature-id"}'
    ```
@@ -53,7 +54,10 @@ Common issues and their solutions when using cf-monitor.
    ```
    Clear it with:
    ```bash
-   curl -X POST .../admin/cb/account -H "Content-Type: application/json" -d '{"status":"clear"}'
+   curl -X POST .../admin/cb/account \
+     -H "Authorization: Bearer YOUR_ADMIN_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"status":"clear"}'
    ```
 
 ## CLI init fails
@@ -98,7 +102,8 @@ Common issues and their solutions when using cf-monitor.
 
 1. **No budget config keys** — check KV for `budget:config:*` keys. If empty, the hourly budget-check cron will auto-seed defaults from `PAID_PLAN_DAILY_BUDGETS` on the next run. Trigger it manually:
    ```bash
-   curl -X POST https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/admin/cron/budget-check
+   curl -X POST https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/admin/cron/budget-check \
+     -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
    ```
 
 2. **Config-sync not run** — if you set custom budgets in `cf-monitor.yaml`, push them to KV:
@@ -119,13 +124,14 @@ Common issues and their solutions when using cf-monitor.
 
 **Causes and fixes**:
 
-1. **SLACK_WEBHOOK_URL not set** — run `npx cf-monitor secret SLACK_WEBHOOK_URL` and paste your Slack incoming webhook URL.
+1. **SLACK_WEBHOOK_URL not set** — run `npx cf-monitor secret set SLACK_WEBHOOK_URL` and paste your Slack incoming webhook URL.
 
 2. **Deduplication** — budget warnings are deduplicated for 1 hour (daily) or 24 hours (monthly). If you just resolved the issue and it triggered again, the alert may be suppressed.
 
 3. **Test the payload** — verify Slack payload formatting:
    ```bash
    curl -X POST https://cf-monitor.YOUR_SUBDOMAIN.workers.dev/admin/test/slack-dry-run \
+     -H "Authorization: Bearer YOUR_ADMIN_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"type":"budget-warning","featureId":"test","metric":"kv_reads","current":900,"limit":1000}'
    ```
@@ -138,7 +144,7 @@ Common issues and their solutions when using cf-monitor.
 
 1. **GITHUB_REPO or GITHUB_TOKEN not set** — both are required. Run:
    ```bash
-   npx cf-monitor secret GITHUB_TOKEN
+   npx cf-monitor secret set GITHUB_TOKEN
    ```
    And ensure `github.repo` is set in cf-monitor.yaml.
 
@@ -149,6 +155,7 @@ Common issues and their solutions when using cf-monitor.
 4. **Test the format** — use the dry-run endpoint to see what would be created:
    ```bash
    curl -X POST .../admin/test/github-dry-run \
+     -H "Authorization: Bearer YOUR_ADMIN_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"scriptName":"my-worker","outcome":"exception","errorMessage":"test error"}'
    ```
@@ -217,3 +224,42 @@ These endpoints are always available on the monitor worker for troubleshooting:
 | `GET /workers` | Which workers have been discovered on the account |
 | `GET /plan` | Detected plan type, billing period, days remaining, plan allowances |
 | `GET /usage` | Account-wide per-service usage from CF GraphQL (approximate) |
+| `GET /self-health` | Self-monitoring: stale crons, error counts, handler breakdown |
+
+## Admin endpoints returning 401
+
+**Symptoms**: All `POST /admin/*` requests return `{"error":"Unauthorized"}`.
+
+**Causes and fixes**:
+
+1. **ADMIN_TOKEN not set** — set the secret on the cf-monitor worker:
+   ```bash
+   openssl rand -hex 32   # Generate a token
+   npx cf-monitor secret set ADMIN_TOKEN
+   ```
+
+2. **Missing Authorization header** — admin requests require:
+   ```bash
+   curl -X POST .../admin/cron/budget-check \
+     -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
+   ```
+
+3. **Wrong token** — ensure the token in the header matches what was set via `secret set`. Tokens are case-sensitive.
+
+4. **Missing "Bearer " prefix** — the header must be `Authorization: Bearer <token>`, not `Authorization: <token>`.
+
+See [Security — Admin endpoint authentication](./security.md#admin-endpoint-authentication) for details.
+
+## Self-monitoring shows stale crons
+
+**Symptoms**: `GET /self-health` returns `503` with `staleCrons` listing one or more handlers.
+
+**Causes and fixes**:
+
+1. **Cron recently deployed** — after first deploy, it may take up to the cron interval (15 min or 1 hour) for all cron handlers to run once. Wait for the next scheduled execution.
+
+2. **Worker not running** — check `npx cf-monitor status` and `wrangler tail cf-monitor` for errors.
+
+3. **KV propagation** — self-monitoring timestamps are stored in KV with 48-hour TTL. Edge cache inconsistency may briefly show stale data.
+
+4. **Actual failure** — if a specific cron handler consistently appears stale, check `wrangler tail cf-monitor` for errors during that handler's schedule. Common causes: API token expired, GitHub rate limit, Slack webhook revoked.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/cf-monitor",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Self-contained Cloudflare account monitoring: error collection, feature budgets, circuit breakers, cost protection. One worker per account.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -1,6 +1,6 @@
 import pc from 'picocolors';
 import { existsSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 interface DeployOptions {
 	dryRun?: boolean;
@@ -24,7 +24,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 	console.log('  Deploying cf-monitor worker...');
 
 	try {
-		const output = execSync(`npx wrangler deploy -c ${wranglerConfig}`, {
+		const output = execFileSync('npx', ['wrangler', 'deploy', '-c', wranglerConfig], {
 			encoding: 'utf-8',
 			stdio: ['inherit', 'pipe', 'pipe'],
 		});

--- a/src/cli/commands/secret.ts
+++ b/src/cli/commands/secret.ts
@@ -1,5 +1,5 @@
 import pc from 'picocolors';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
 const KNOWN_SECRETS = [
@@ -23,7 +23,11 @@ export async function secretSetCommand(name: string, _options: SecretOptions): P
 		process.exit(1);
 	}
 
-	if (!name) {
+	if (!name || !/^[A-Z_][A-Z0-9_]*$/.test(name)) {
+		if (name) {
+			console.error(pc.red(`  Invalid secret name: ${name}. Must match /^[A-Z_][A-Z0-9_]*$/.`));
+			process.exit(1);
+		}
 		console.log(pc.bold('\ncf-monitor secret set\n'));
 		console.log('  Known secrets:');
 		for (const s of KNOWN_SECRETS) {
@@ -37,7 +41,7 @@ export async function secretSetCommand(name: string, _options: SecretOptions): P
 
 	try {
 		// wrangler secret put reads from stdin interactively
-		execSync(`npx wrangler secret put ${name} -c ${configPath}`, {
+		execFileSync('npx', ['wrangler', 'secret', 'put', name, '-c', configPath], {
 			stdio: 'inherit',
 		});
 		console.log(pc.green(`\n  Secret ${name} set successfully.`));

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -1,5 +1,5 @@
 import pc from 'picocolors';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
 interface UpgradeOptions {
@@ -47,7 +47,7 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
 
 		// Step 3: Deploy
 		console.log('\n  Deploying updated worker...');
-		execSync(`npx wrangler deploy -c ${configPath}`, { stdio: 'inherit' });
+		execFileSync('npx', ['wrangler', 'deploy', '-c', configPath], { stdio: 'inherit' });
 
 		// Step 4: Health check
 		console.log('\n  Verifying deployment...');

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,7 @@ export interface MonitorWorkerEnv {
 	CLOUDFLARE_API_TOKEN?: string;
 	GATUS_HEARTBEAT_URL?: string;
 	GATUS_TOKEN?: string;
+	ADMIN_TOKEN?: string;
 	AI?: Ai;
 }
 
@@ -301,7 +302,7 @@ export interface CfMonitorConfig {
 // =============================================================================
 
 /** Marker symbol for tracked environments. */
-export const TRACKED_ENV_SYMBOL = Symbol.for('cf-monitor:tracked');
+export const TRACKED_ENV_SYMBOL = Symbol('cf-monitor:tracked');
 
 /** A worker env that has been wrapped with metric-tracking proxies. */
 export type TrackedEnv<Env extends object = object> = Env & {

--- a/src/worker/crons/collect-account-usage.ts
+++ b/src/worker/crons/collect-account-usage.ts
@@ -13,9 +13,17 @@ const USAGE_DISCLAIMER = 'Approximate — from CF GraphQL Analytics API. Not aut
  * NOT available in GraphQL: AI Gateway, Vectorize, Queues, Workflows, Hyperdrive.
  * These services use REST APIs or dashboard-only metrics — may be added later.
  */
+/** Validate account ID format to prevent GraphQL injection. */
+const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/i;
+
 export async function collectAccountUsage(env: MonitorWorkerEnv): Promise<void> {
 	if (!env.CLOUDFLARE_API_TOKEN || !env.CF_ACCOUNT_ID) {
 		console.warn('[cf-monitor:usage] No CLOUDFLARE_API_TOKEN or CF_ACCOUNT_ID — skipping usage collection');
+		return;
+	}
+
+	if (!ACCOUNT_ID_RE.test(env.CF_ACCOUNT_ID)) {
+		console.error('[cf-monitor:usage] Invalid CF_ACCOUNT_ID format — must be 32-char hex');
 		return;
 	}
 

--- a/src/worker/crons/collect-metrics.ts
+++ b/src/worker/crons/collect-metrics.ts
@@ -4,9 +4,17 @@ import type { MonitorWorkerEnv } from '../../types.js';
  * Hourly: Collect account-level metrics from Cloudflare GraphQL Analytics API.
  * Writes to Analytics Engine for time-series storage.
  */
+/** Validate account ID format to prevent GraphQL injection. */
+const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/i;
+
 export async function collectAccountMetrics(env: MonitorWorkerEnv): Promise<void> {
 	if (!env.CLOUDFLARE_API_TOKEN || !env.CF_ACCOUNT_ID) {
 		console.warn('[cf-monitor:collect] No CLOUDFLARE_API_TOKEN or CF_ACCOUNT_ID configured');
+		return;
+	}
+
+	if (!ACCOUNT_ID_RE.test(env.CF_ACCOUNT_ID)) {
+		console.error('[cf-monitor:collect] Invalid CF_ACCOUNT_ID format — must be 32-char hex');
 		return;
 	}
 

--- a/src/worker/errors/github.ts
+++ b/src/worker/errors/github.ts
@@ -65,17 +65,22 @@ export async function createGitHubIssue(
 	}
 }
 
+/** Escape markdown-active characters for safe interpolation in table cells. */
+function escapeMd(s: string): string {
+	return s.replace(/[|`\[\]()!*_~<>\\]/g, '\\$&');
+}
+
 function formatIssueBody(params: ErrorIssueParams): string {
 	return `## Error Details
 
 | Field | Value |
 |-------|-------|
-| **Worker** | \`${params.scriptName}\` |
-| **Outcome** | \`${params.outcome}\` |
-| **Priority** | ${params.priority} |
-| **Account** | ${params.accountName} |
+| **Worker** | \`${escapeMd(params.scriptName)}\` |
+| **Outcome** | \`${escapeMd(params.outcome)}\` |
+| **Priority** | ${escapeMd(params.priority)} |
+| **Account** | ${escapeMd(params.accountName)} |
 | **Transient** | ${params.isTransient ? 'Yes' : 'No'} |
-| **Fingerprint** | \`${params.fingerprint}\` |
+| **Fingerprint** | \`${escapeMd(params.fingerprint)}\` |
 
 ### Error
 

--- a/src/worker/fetch-handler.ts
+++ b/src/worker/fetch-handler.ts
@@ -37,12 +37,20 @@ export async function handleFetch(
 	// POST routes
 	if (request.method === 'POST') {
 		if (path === '/webhooks/github') return handleGitHubWebhook(request, env);
-		if (path.startsWith('/admin/cron/')) return handleAdminCronTrigger(path, env);
-		if (path === '/admin/cb/trip') return handleAdminCbTrip(request, env);
-		if (path === '/admin/cb/reset') return handleAdminCbReset(request, env);
-		if (path === '/admin/cb/account') return handleAdminCbAccount(request, env);
-		if (path === '/admin/test/github-dry-run') return handleGitHubDryRun(request, env);
-		if (path === '/admin/test/slack-dry-run') return handleSlackDryRun(request);
+
+		// Admin routes require Bearer token authentication
+		if (path.startsWith('/admin/')) {
+			if (!verifyAdminToken(request, env)) {
+				return Response.json({ error: 'Unauthorized' }, { status: 401 });
+			}
+			if (path.startsWith('/admin/cron/')) return handleAdminCronTrigger(path, env);
+			if (path === '/admin/cb/trip') return handleAdminCbTrip(request, env);
+			if (path === '/admin/cb/reset') return handleAdminCbReset(request, env);
+			if (path === '/admin/cb/account') return handleAdminCbAccount(request, env);
+			if (path === '/admin/test/github-dry-run') return handleGitHubDryRun(request, env);
+			if (path === '/admin/test/slack-dry-run') return handleSlackDryRun(request);
+		}
+
 		return Response.json({ error: 'Not found' }, { status: 404 });
 	}
 
@@ -100,19 +108,17 @@ async function handleSelfHealth(env: MonitorWorkerEnv): Promise<Response> {
 }
 
 async function handleStatus(env: MonitorWorkerEnv): Promise<Response> {
-	const [accountCb, globalCb, workerList, plan, billingPeriod] = await Promise.all([
+	const [accountCb, globalCb, workerList, plan] = await Promise.all([
 		env.CF_MONITOR_KV.get(KV.CB_ACCOUNT),
 		env.CF_MONITOR_KV.get(KV.CB_GLOBAL),
 		env.CF_MONITOR_KV.get(KV.WORKER_LIST),
 		getPlanOrCached(env),
-		getBillingPeriodOrCached(env),
 	]);
 
 	const workers = workerList ? JSON.parse(workerList) as string[] : [];
 
 	return Response.json({
 		account: env.ACCOUNT_NAME,
-		accountId: env.CF_ACCOUNT_ID,
 		plan,
 		healthy: !globalCb && accountCb !== 'paused',
 		circuitBreaker: {
@@ -121,10 +127,8 @@ async function handleStatus(env: MonitorWorkerEnv): Promise<Response> {
 		},
 		workers: {
 			count: workers.length,
-			names: workers,
 		},
-		billingPeriod: billingPeriod ?? undefined,
-		github: env.GITHUB_REPO ? { repo: env.GITHUB_REPO, configured: true } : { configured: false },
+		github: { configured: !!env.GITHUB_REPO },
 		slack: { configured: !!env.SLACK_WEBHOOK_URL },
 		timestamp: Date.now(),
 	});
@@ -278,10 +282,11 @@ async function handleAdminCronTrigger(path: string, env: MonitorWorkerEnv): Prom
 			durationMs: Date.now() - start,
 		});
 	} catch (err) {
+		console.error(`[cf-monitor:admin] ${cronName} error:`, err);
 		return Response.json({
 			ok: false,
 			cron: cronName,
-			error: String(err),
+			error: 'Internal error',
 			durationMs: Date.now() - start,
 		}, { status: 500 });
 	}
@@ -300,7 +305,8 @@ async function handleAdminCbTrip(request: Request, env: MonitorWorkerEnv): Promi
 		await tripFeatureCb(env.CF_MONITOR_KV, body.featureId, body.reason ?? 'admin', body.ttlSeconds ?? 3600);
 		return Response.json({ ok: true, action: 'trip', featureId: body.featureId });
 	} catch (err) {
-		return Response.json({ error: String(err) }, { status: 500 });
+		console.error('[cf-monitor:admin] CB trip error:', err);
+		return Response.json({ error: 'Internal error' }, { status: 500 });
 	}
 }
 
@@ -313,7 +319,8 @@ async function handleAdminCbReset(request: Request, env: MonitorWorkerEnv): Prom
 		await resetFeatureCb(env.CF_MONITOR_KV, body.featureId);
 		return Response.json({ ok: true, action: 'reset', featureId: body.featureId });
 	} catch (err) {
-		return Response.json({ error: String(err) }, { status: 500 });
+		console.error('[cf-monitor:admin] CB reset error:', err);
+		return Response.json({ error: 'Internal error' }, { status: 500 });
 	}
 }
 
@@ -330,7 +337,8 @@ async function handleAdminCbAccount(request: Request, env: MonitorWorkerEnv): Pr
 		}
 		return Response.json({ ok: true, action: 'account', status: body.status });
 	} catch (err) {
-		return Response.json({ error: String(err) }, { status: 500 });
+		console.error('[cf-monitor:admin] CB account error:', err);
+		return Response.json({ error: 'Internal error' }, { status: 500 });
 	}
 }
 
@@ -376,7 +384,8 @@ async function handleGitHubDryRun(request: Request, env: MonitorWorkerEnv): Prom
 
 		return Response.json({ title, body: issueBody, labels, fingerprint, priority, isTransient });
 	} catch (err) {
-		return Response.json({ error: String(err) }, { status: 500 });
+		console.error('[cf-monitor:admin] GitHub dry-run error:', err);
+		return Response.json({ error: 'Internal error' }, { status: 500 });
 	}
 }
 
@@ -394,12 +403,12 @@ function formatDryRunIssueBody(params: {
 
 | Field | Value |
 |-------|-------|
-| **Worker** | \`${params.scriptName}\` |
-| **Outcome** | \`${params.outcome}\` |
-| **Priority** | ${params.priority} |
-| **Account** | ${params.accountName} |
+| **Worker** | \`${escapeMdCell(params.scriptName)}\` |
+| **Outcome** | \`${escapeMdCell(params.outcome)}\` |
+| **Priority** | ${escapeMdCell(params.priority)} |
+| **Account** | ${escapeMdCell(params.accountName)} |
 | **Transient** | ${params.isTransient ? 'Yes' : 'No'} |
-| **Fingerprint** | \`${params.fingerprint}\` |
+| **Fingerprint** | \`${escapeMdCell(params.fingerprint)}\` |
 
 ### Error
 
@@ -462,7 +471,8 @@ async function handleSlackDryRun(request: Request): Promise<Response> {
 
 		return Response.json({ error: `Unknown type: ${type}` }, { status: 400 });
 	} catch (err) {
-		return Response.json({ error: String(err) }, { status: 500 });
+		console.error('[cf-monitor:admin] Slack dry-run error:', err);
+		return Response.json({ error: 'Internal error' }, { status: 500 });
 	}
 }
 
@@ -486,6 +496,17 @@ async function handleGitHubWebhook(request: Request, env: MonitorWorkerEnv): Pro
 	const isValid = await verifyHmacSha256(body, signature, secret);
 	if (!isValid) {
 		return Response.json({ error: 'Invalid signature' }, { status: 401 });
+	}
+
+	// Replay protection: reject duplicate delivery IDs
+	const deliveryId = request.headers.get('X-GitHub-Delivery');
+	if (deliveryId) {
+		const nonceKey = `webhook:nonce:${deliveryId}`;
+		const existing = await env.CF_MONITOR_KV.get(nonceKey);
+		if (existing) {
+			return Response.json({ ok: true, skipped: true, reason: 'Duplicate delivery' });
+		}
+		await env.CF_MONITOR_KV.put(nonceKey, '1', { expirationTtl: 86400 }); // 24hr
 	}
 
 	const event = request.headers.get('X-GitHub-Event');
@@ -534,6 +555,26 @@ async function handleGitHubWebhook(request: Request, env: MonitorWorkerEnv): Pro
 		console.error(`[cf-monitor:webhook] Error processing ${action}: ${err}`);
 		return Response.json({ error: 'Processing failed' }, { status: 500 });
 	}
+}
+
+/** Escape markdown-active characters for safe table cell interpolation. */
+function escapeMdCell(s: string): string {
+	return s.replace(/[|`\[\]()!*_~<>\\]/g, '\\$&');
+}
+
+/** Verify admin token from Authorization: Bearer header. */
+function verifyAdminToken(request: Request, env: MonitorWorkerEnv): boolean {
+	if (!env.ADMIN_TOKEN) return false;
+	const header = request.headers.get('Authorization');
+	if (!header) return false;
+	const token = header.startsWith('Bearer ') ? header.slice(7) : '';
+	if (token.length !== env.ADMIN_TOKEN.length) return false;
+	// Timing-safe comparison
+	let result = 0;
+	for (let i = 0; i < token.length; i++) {
+		result |= token.charCodeAt(i) ^ env.ADMIN_TOKEN.charCodeAt(i);
+	}
+	return result === 0;
 }
 
 /** Verify HMAC-SHA256 signature from GitHub webhook. */

--- a/tests/worker/crons/collect-account-usage.test.ts
+++ b/tests/worker/crons/collect-account-usage.test.ts
@@ -14,7 +14,7 @@ function mockEnv(overrides?: Partial<MonitorWorkerEnv>): MonitorWorkerEnv {
 			getWithMetadata: vi.fn(async () => ({ value: null, metadata: null, cacheStatus: null })),
 		} as unknown as KVNamespace,
 		CF_MONITOR_AE: { writeDataPoint: vi.fn() } as unknown as AnalyticsEngineDataset,
-		CF_ACCOUNT_ID: 'test-account-id',
+		CF_ACCOUNT_ID: 'aabbccdd11223344aabbccdd11223344',
 		ACCOUNT_NAME: 'test-account',
 		CLOUDFLARE_API_TOKEN: 'test-token',
 		...overrides,

--- a/tests/worker/fetch-handler.test.ts
+++ b/tests/worker/fetch-handler.test.ts
@@ -24,7 +24,7 @@ describe('handleFetch', () => {
 
 		expect(resp.status).toBe(200);
 		expect((body.workers as Record<string, unknown>).count).toBe(2);
-		expect(body.accountId).toBe('test-account-id');
+		expect(body.accountId).toBeUndefined(); // stripped for security (M6)
 	});
 
 	it('GET /errors lists fingerprints from KV', async () => {


### PR DESCRIPTION
## Summary

Full security audit of cf-monitor v0.3.2 with 9 fixes addressing 1 HIGH and 8 MEDIUM findings. All fixes implemented, tested (286/286 pass), and documented.

### Security Fixes

- **H1**: Admin endpoint auth — all `/admin/*` routes now require `Authorization: Bearer <ADMIN_TOKEN>` (#62)
- **M1**: CLI command injection — `execSync` → `execFileSync` in 3 CLI files (#63)
- **M2**: Markdown injection — `escapeMd()` helper for GitHub issue table cells (#64)
- **M3**: GraphQL input validation — `CF_ACCOUNT_ID` format check (#65)
- **M4**: KV TOCTOU race — documented as known limitation (#66)
- **M5**: Symbol privacy — `Symbol.for()` → `Symbol()` (#67)
- **M6**: Info disclosure — `/status` stripped of sensitive fields (#68)
- **M7**: Webhook replay protection — `X-GitHub-Delivery` nonce (#69)
- **M8**: Error response hardening — generic messages (#70)

### Documentation

- New `docs/security.md` — comprehensive security guide
- Updated getting-started, troubleshooting, configuration, README
- Fixed CLI `secret` syntax across all docs
- All admin curl examples include auth headers

### Issues

14 security issues created (#62-#75): 12 closed (fixed), 2 open (L4 CORS, L5 duck-typing — backlog)

## Test plan

- [x] `npm test` — 286 unit tests pass
- [x] `npm run typecheck` — clean
- [ ] CI: typecheck (Node 20 + 22), tests, coverage, CLI build, smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)