### PR TITLE
feat: v0.3.4 CORS headers + excludeBindings option (#74, #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to cf-monitor are documented here. This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
+## [0.3.4] - 2026-03-22
+
+### Added
+- CORS headers on all GET endpoints — `Access-Control-Allow-Origin: *` enables browser-based monitoring dashboards (#74)
+- OPTIONS preflight handler returns 204 with CORS headers
+- `excludeBindings` option in `MonitorConfig` — skip proxy wrapping for specific env binding names that accidentally match CF binding method signatures (#75)
+
+### Changed
+- `createTrackedEnv()` accepts optional `excludeBindings` parameter, merged with internal skip set
+- `detectBindings()` accepts optional `excludeKeys` parameter
+- `docs/security.md` — updated duck-typing section with `excludeBindings` mitigation
+- `docs/configuration.md` — added `excludeBindings` to SDK Options section
+- Unit tests increased from 286 to 290
+
 ## [0.3.3] - 2026-03-22
 
 ### Security
@@ -149,6 +163,7 @@ All notable changes to cf-monitor are documented here. This project follows [Kee
 - CI pipeline: Node 20/22 matrix, publint, attw, lockfile-lint, package validation
 - Release workflow: tag-triggered npm publish
 
+[0.3.4]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.0...v0.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,12 @@ Deployed 2026-03-21 on Platform CF account (`55a0bf6d...`):
 
 **#44 — Self-monitoring**: cf-monitor now tracks its own handler execution, errors, and cron staleness. New `self-monitor.ts` module provides fail-open recording functions. All 3 handlers (tail, scheduled, fetch) are instrumented. New `GET /self-health` endpoint returns handler status, error counts, and stale cron detection (200 when healthy, 503 when stale). Staleness alerts via Slack (1/day dedup). Self-telemetry written to AE (`blob2` format: `self:{durationMs}:{1|0}`, `doubles[0]=1`). New KV prefixes: `self:v1:cron:last_run` (handler timestamps as single JSON blob), `self:v1:error:{handler}:{date}` (error counts), `self:v1:errors:count:{date}` (daily total). `CRON_HANDLER_REGISTRY` constant for staleness thresholds. Admin cron trigger: `POST /admin/cron/staleness-check`. Phase 3 (self-capture via error pipeline) deferred to future version.
 
+## v0.3.4 CORS + Binding Exclusion
+
+- **CORS headers**: All GET endpoints include `Access-Control-Allow-Origin: *`. OPTIONS preflight returns 204. POST endpoints unchanged (server-to-server only). (#74)
+- **`excludeBindings` option**: New `MonitorConfig.excludeBindings?: string[]` — env binding names to skip from proxy wrapping. Prevents false-positive metric tracking on custom env objects that match CF binding method signatures. (#75)
+- Updated `docs/security.md` with "Binding detection" section documenting `excludeBindings` as mitigation.
+
 ## v0.3.3 Security Hardening
 
 Full security audit with 9 fixes:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ export default monitor({
 |---------|-------------|-----------------|
 | Worker name | `config.workerName` > `env.WORKER_NAME` > `env.name` > `'worker'` | `workerName` option or `wire --apply` |
 | Feature IDs | `{worker}:{handler}:{method}:{path-slug}` | `featureId`, `featurePrefix`, or `features` map |
-| Bindings | Duck-typing at runtime (D1, KV, R2, AI, Queue, DO, Vectorize, Workflow) | — |
+| Bindings | Duck-typing at runtime (D1, KV, R2, AI, Queue, DO, Vectorize, Workflow) | `excludeBindings` to skip specific keys |
 | Budget defaults | Auto-detected from CF plan (free/paid) via Subscriptions API | `budgets` in config or `config sync` CLI |
 | Health endpoint | `/_monitor/health` | `healthEndpoint` option or `false` to disable |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,17 @@ monitor({
 })
 ```
 
+### Binding exclusion
+
+```typescript
+monitor({
+  excludeBindings: ['MY_CUSTOM_STORE'],  // Skip proxy wrapping for these env keys
+  fetch: handler,
+})
+```
+
+Use when custom env objects accidentally match CF binding method signatures (e.g. an object with `get()`, `put()`, `delete()`, `list()` methods). See [Security — Binding detection](./security.md#binding-detection).
+
 ### Options
 
 ```typescript

--- a/docs/security.md
+++ b/docs/security.md
@@ -134,6 +134,23 @@ This prevents sensitive data (user IDs, tokens in paths) from appearing in featu
 
 The internal tracking metadata (metrics, feature ID, worker name) is stored on the env proxy using a module-private `Symbol()`. This is not discoverable by other code in the isolate, preventing malicious npm dependencies from reading internal metrics or worker names.
 
+## Binding detection
+
+cf-monitor uses duck-typing to identify Cloudflare binding types at runtime (checking for method signatures like `prepare()` + `batch()` for D1, `get()` + `put()` + `delete()` + `list()` for KV, etc.). This is fragile — a custom object on `env` matching these signatures would be incorrectly wrapped as a CF binding and tracked in metrics.
+
+**Mitigation**: Use the `excludeBindings` option to skip specific env keys from proxy wrapping:
+
+```typescript
+export default monitor({
+  excludeBindings: ['MY_CUSTOM_STORE', 'LEGACY_API_CLIENT'],
+  fetch: handler,
+});
+```
+
+Keys listed in `excludeBindings` are returned unwrapped (no metric tracking). cf-monitor's own bindings (`CF_MONITOR_KV`, `CF_MONITOR_AE`) are always excluded automatically.
+
+In practice, the risk is low — env bindings are set at deploy time by Cloudflare, and custom objects rarely match CF binding method signatures. But if you have a custom env object with `get()`, `put()`, `delete()`, and `list()` methods, `excludeBindings` is the escape hatch.
+
 ## Error message handling
 
 ### Truncation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/cf-monitor",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Self-contained Cloudflare account monitoring: error collection, feature budgets, circuit breakers, cost protection. One worker per account.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/sdk/detection.ts
+++ b/src/sdk/detection.ts
@@ -105,7 +105,7 @@ export interface BindingInventory {
  * Auto-detect Cloudflare resource bindings in the worker environment.
  * Uses duck-typing to identify binding types.
  */
-export function detectBindings(env: object): BindingInventory {
+export function detectBindings(env: object, excludeKeys?: string[]): BindingInventory {
 	const inventory: BindingInventory = {
 		d1: [],
 		kv: [],
@@ -119,6 +119,9 @@ export function detectBindings(env: object): BindingInventory {
 	};
 
 	const skipKeys = new Set([MONITOR_BINDINGS.KV, MONITOR_BINDINGS.AE, 'WORKER_NAME']);
+	if (excludeKeys) {
+		for (const key of excludeKeys) skipKeys.add(key);
+	}
 
 	for (const [key, value] of Object.entries(env)) {
 		if (skipKeys.has(key)) continue;

--- a/src/sdk/monitor.ts
+++ b/src/sdk/monitor.ts
@@ -52,6 +52,7 @@ export function monitor<Env extends object = object>(
 	const healthPath = config.healthEndpoint === false ? null : (config.healthEndpoint ?? '/_monitor/health');
 	const limits = config.limits;
 	const configWorkerName = config.workerName;
+	const excludeBindings = config.excludeBindings;
 
 	const worker: ExportedHandler<Env> = {};
 
@@ -100,7 +101,7 @@ export function monitor<Env extends object = object>(
 				return Response.json({ error: 'Feature temporarily unavailable', feature: featureId }, { status: 503 });
 			}
 
-			const trackedEnv = createTrackedEnv(env, featureId, workerName, limits);
+			const trackedEnv = createTrackedEnv(env, featureId, workerName, limits, excludeBindings);
 
 			try {
 				return await config.fetch(request, trackedEnv as unknown as Env, ctx);
@@ -153,7 +154,7 @@ export function monitor<Env extends object = object>(
 				return;
 			}
 
-			const trackedEnv = createTrackedEnv(env, featureId, workerName, limits);
+			const trackedEnv = createTrackedEnv(env, featureId, workerName, limits, excludeBindings);
 			let success = false;
 
 			try {
@@ -211,7 +212,7 @@ export function monitor<Env extends object = object>(
 				return;
 			}
 
-			const trackedEnv = createTrackedEnv(env, featureId, workerName, limits);
+			const trackedEnv = createTrackedEnv(env, featureId, workerName, limits, excludeBindings);
 
 			try {
 				await userQueue(batch, trackedEnv as unknown as Env, ctx);

--- a/src/sdk/proxy.ts
+++ b/src/sdk/proxy.ts
@@ -14,10 +14,15 @@ export function createTrackedEnv<Env extends object>(
 	env: Env,
 	featureId: string,
 	workerName: string,
-	limits?: RequestLimits
+	limits?: RequestLimits,
+	excludeBindings?: string[]
 ): TrackedEnv<Env> {
 	const metrics = createMetrics();
 	const startTime = Date.now();
+	const skipKeys = new Set<string | symbol>([MONITOR_BINDINGS.KV, MONITOR_BINDINGS.AE]);
+	if (excludeBindings) {
+		for (const key of excludeBindings) skipKeys.add(key);
+	}
 
 	const handler: ProxyHandler<Env> = {
 		get(target, prop, receiver) {
@@ -29,8 +34,8 @@ export function createTrackedEnv<Env extends object>(
 			const value = Reflect.get(target, prop, receiver);
 			if (value == null || typeof value !== 'object') return value;
 
-			// Skip monitor's own bindings
-			if (prop === MONITOR_BINDINGS.KV || prop === MONITOR_BINDINGS.AE) return value;
+			// Skip monitor's own bindings and user-excluded bindings
+			if (skipKeys.has(prop)) return value;
 
 			// Wrap known binding types
 			if (isD1Database(value)) return wrapD1(value, metrics, limits);

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,13 @@ export interface MonitorConfig<Env extends object = object> {
 
 	/** Max recursion depth for anti-loop guard. Default: 5. */
 	maxRecursionDepth?: number;
+
+	/**
+	 * Env binding names to exclude from proxy wrapping.
+	 * Use when custom env objects accidentally match CF binding method signatures.
+	 * These keys will be returned unwrapped (no metric tracking).
+	 */
+	excludeBindings?: string[];
 }
 
 // =============================================================================

--- a/src/worker/fetch-handler.ts
+++ b/src/worker/fetch-handler.ts
@@ -16,6 +16,18 @@ import { collectAccountUsage } from './crons/collect-account-usage.js';
 import { getPlanOrCached, getBillingPeriodOrCached } from './account/subscriptions.js';
 import { getAllowancesForPlan } from './account/plan-allowances.js';
 
+// CORS headers for GET endpoints — allows browser-based monitoring dashboards
+const CORS_HEADERS: Record<string, string> = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET, OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+/** Response.json() with CORS headers for GET endpoints. */
+function jsonWithCors(data: unknown, status = 200): Response {
+	return Response.json(data, { status, headers: CORS_HEADERS });
+}
+
 /**
  * API endpoints for the cf-monitor worker.
  *
@@ -54,6 +66,11 @@ export async function handleFetch(
 		return Response.json({ error: 'Not found' }, { status: 404 });
 	}
 
+	// CORS preflight for browser-based access
+	if (request.method === 'OPTIONS') {
+		return new Response(null, { status: 204, headers: CORS_HEADERS });
+	}
+
 	if (request.method !== 'GET') {
 		return Response.json({ error: 'Method not allowed' }, { status: 405 });
 	}
@@ -80,7 +97,7 @@ export async function handleFetch(
 // =============================================================================
 
 async function handleHealth(env: MonitorWorkerEnv): Promise<Response> {
-	return Response.json({
+	return jsonWithCors({
 		healthy: true,
 		account: env.ACCOUNT_NAME,
 		timestamp: Date.now(),
@@ -90,20 +107,20 @@ async function handleHealth(env: MonitorWorkerEnv): Promise<Response> {
 async function handleSelfHealth(env: MonitorWorkerEnv): Promise<Response> {
 	try {
 		const status = await getSelfHealth(env);
-		return Response.json({
+		return jsonWithCors({
 			healthy: status.healthy,
 			staleCrons: status.staleCrons,
 			errors: status.todayErrors,
 			handlers: status.handlerErrors,
 			crons: status.crons,
 			timestamp: Date.now(),
-		}, { status: status.healthy ? 200 : 503 });
+		}, status.healthy ? 200 : 503);
 	} catch (err) {
-		return Response.json({
+		return jsonWithCors({
 			healthy: false,
 			error: 'Failed to gather self-health',
 			timestamp: Date.now(),
-		}, { status: 500 });
+		}, 500);
 	}
 }
 
@@ -117,7 +134,7 @@ async function handleStatus(env: MonitorWorkerEnv): Promise<Response> {
 
 	const workers = workerList ? JSON.parse(workerList) as string[] : [];
 
-	return Response.json({
+	return jsonWithCors({
 		account: env.ACCOUNT_NAME,
 		plan,
 		healthy: !globalCb && accountCb !== 'paused',
@@ -147,7 +164,7 @@ async function handleErrors(env: MonitorWorkerEnv): Promise<Response> {
 		}
 	}
 
-	return Response.json({
+	return jsonWithCors({
 		account: env.ACCOUNT_NAME,
 		errors,
 		count: errors.length,
@@ -166,7 +183,7 @@ async function handlePlan(env: MonitorWorkerEnv): Promise<Response> {
 		? Math.max(0, Math.ceil((new Date(billingPeriod.end).getTime() - Date.now()) / 86_400_000))
 		: undefined;
 
-	return Response.json({
+	return jsonWithCors({
 		account: env.ACCOUNT_NAME,
 		plan,
 		billingPeriod: billingPeriod ?? undefined,
@@ -187,7 +204,7 @@ async function handleUsage(env: MonitorWorkerEnv): Promise<Response> {
 	const allowances = getAllowancesForPlan(plan);
 	const snapshot = snapshotRaw ? JSON.parse(snapshotRaw) : null;
 
-	return Response.json({
+	return jsonWithCors({
 		account: env.ACCOUNT_NAME,
 		plan,
 		billingPeriod: billingPeriod ?? undefined,
@@ -225,7 +242,7 @@ async function handleBudgets(env: MonitorWorkerEnv): Promise<Response> {
 		breakers.push({ featureId, status });
 	}
 
-	return Response.json({
+	return jsonWithCors({
 		account: env.ACCOUNT_NAME,
 		billingPeriod: billingPeriod ?? undefined,
 		circuitBreakers: breakers,
@@ -238,7 +255,7 @@ async function handleWorkers(env: MonitorWorkerEnv): Promise<Response> {
 	const workerList = await env.CF_MONITOR_KV.get(KV.WORKER_LIST);
 	const workers = workerList ? JSON.parse(workerList) as string[] : [];
 
-	return Response.json({
+	return jsonWithCors({
 		account: env.ACCOUNT_NAME,
 		workers,
 		count: workers.length,

--- a/tests/sdk/proxy.test.ts
+++ b/tests/sdk/proxy.test.ts
@@ -241,6 +241,31 @@ describe('Durable Object proxy (#12)', () => {
 	});
 });
 
+describe('excludeBindings (#75)', () => {
+	it('excluded binding keys are NOT wrapped', async () => {
+		const env = createMockConsumerEnv();
+		const te = createTrackedEnv(env, 'test:fetch:GET:api', 'test-worker', undefined, ['MY_KV']);
+		const info = getTrackingInfo(te);
+
+		// MY_KV is in excludeBindings — accessing it should return the raw mock
+		const kv = (te as any).MY_KV;
+		expect(kv).toBe(env.MY_KV);
+		await kv.get('test');
+		// kvReads should NOT have incremented
+		expect(info.metrics.kvReads).toBe(0);
+	});
+
+	it('non-excluded bindings are still wrapped normally', async () => {
+		const env = createMockConsumerEnv();
+		const te = createTrackedEnv(env, 'test:fetch:GET:api', 'test-worker', undefined, ['MY_KV']);
+		const info = getTrackingInfo(te);
+
+		// DB is NOT excluded — should still be tracked
+		await (te as any).DB.prepare('SELECT 1').first();
+		expect(info.metrics.d1Reads).toBe(1);
+	});
+});
+
 describe('Workflow proxy (#12)', () => {
 	it('workflow.create() increments workflowInvocations', async () => {
 		const { te, metrics } = tracked();

--- a/tests/worker/fetch-handler.test.ts
+++ b/tests/worker/fetch-handler.test.ts
@@ -96,6 +96,25 @@ describe('handleFetch', () => {
 		expect(body.count).toBe(2);
 	});
 
+	it('GET endpoints include CORS headers', async () => {
+		const env = createMockMonitorWorkerEnv();
+		const resp = await handleFetch(createRequest('/_health'), env, createMockCtx());
+
+		expect(resp.headers.get('Access-Control-Allow-Origin')).toBe('*');
+		expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, OPTIONS');
+	});
+
+	it('OPTIONS returns 204 with CORS headers', async () => {
+		const env = createMockMonitorWorkerEnv();
+		const req = new Request('http://localhost/_health', { method: 'OPTIONS' });
+		const resp = await handleFetch(req, env, createMockCtx());
+
+		expect(resp.status).toBe(204);
+		expect(resp.headers.get('Access-Control-Allow-Origin')).toBe('*');
+		expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, OPTIONS');
+		expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type');
+	});
+
 	it('POST to non-webhook path returns 404', async () => {
 		const env = createMockMonitorWorkerEnv();
 		const resp = await handleFetch(createRequest('/status', 'POST'), env, createMockCtx());


### PR DESCRIPTION
## Summary

Closes the last two security backlog items from the v0.3.3 audit.

### #74: CORS headers on GET endpoints
- All GET responses include `Access-Control-Allow-Origin: *`
- OPTIONS preflight returns 204 with full CORS headers
- POST endpoints (admin, webhooks) unchanged — server-to-server only

### #75: `excludeBindings` option
- New `MonitorConfig.excludeBindings?: string[]` — env keys to skip from proxy wrapping
- Prevents false-positive metric tracking when custom env objects match CF binding method signatures
- Threaded through `createTrackedEnv()` and `detectBindings()`

### Documentation
- `docs/security.md` — new "Binding detection" section with `excludeBindings` mitigation
- `docs/configuration.md` — added excludeBindings to SDK Options
- `README.md` — updated auto-detection table

## Test plan
- [x] 290 tests pass (4 new: CORS headers, OPTIONS, excludeBindings skip, excludeBindings non-interference)
- [x] `npm run typecheck` clean
- [ ] CI: Node 20 + 22, typecheck, tests, coverage, CLI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)