### PR TITLE
fix: v0.3.8 — Brand Copilot issue flood fixes (#92-#99)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
     id: version
     attributes:
       label: cf-monitor version
-      placeholder: "0.3.7"
+      placeholder: "0.3.8"
     validations:
       required: true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,10 @@ cf-monitor/
       errors/             # Fingerprinting, patterns, GitHub issue CRUD
       alerts/             # Slack alerts with dedup
       account/            # Plan detection, billing period, allowances
-      optional/           # STUB handlers for AI features (pattern-discovery, health-reporter, coverage-auditor) — not yet implemented in v0.3.7
+      optional/           # STUB handlers for AI features (pattern-discovery, health-reporter, coverage-auditor) — not yet implemented in v0.3.8
     cli/                  # CLI: npx cf-monitor <command>
       commands/           # 9 commands: init, deploy, wire, status, coverage, secret, config-sync, upgrade, migrate, usage
-  tests/                  # 316 unit tests + 53 integration tests (10 files)
+  tests/                  # 338 unit tests + 53 integration tests (10 files)
   worker/                 # Pre-built entry for wrangler deploy
   docs/                   # 20 documentation files (getting-started, configuration, security, troubleshooting + 10 guides + 3 how-to)
 ```
@@ -54,12 +54,12 @@ cf-monitor/
 - **No D1**: Analytics Engine for metrics, KV for state. Zero database migrations.
 - **Australian English**: realise, colour, licence
 
-## Stubs & Partial Features (v0.3.7)
+## Stubs & Partial Features (v0.3.8)
 
 Do not assume these work end-to-end:
 
 - `src/worker/optional/pattern-discovery.ts`, `health-reporter.ts`, `coverage-auditor.ts` — stubs. Enabling `ai.*` flags in `cf-monitor.yaml` is a no-op. Tracked: #8, #9, #10.
-- `transient_patterns:` YAML key — parsed and loaded into `env._customTransientPatterns`, but `src/worker/errors/patterns.ts` `matchTransientPattern()` only consults built-ins. Tracked: #92.
+- `monitoring.spike_threshold` — schema validates but `cost-spike.ts` hardcodes `2.0`. Values in YAML are ignored.
 - `monitoring.spike_threshold` YAML key — schema validates but `src/worker/crons/cost-spike.ts:7` hardcodes `2.0`.
 
 If you're asked to use any of these, implement the missing wiring first or flag the stub to the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,26 @@ All notable changes to cf-monitor are documented here. This project follows [Kee
 
 ## [Unreleased]
 
-## [0.3.7] - 2026-03-31
+## [0.3.8] - 2026-04-15
+
+### Fixed
+- Cloudflare removed `cpuTime` from `sum` selection on `workersInvocationsAdaptive` — replaced with `quantiles { cpuTimeP50 }` in both `collect-account-usage.ts` and `collect-metrics.ts`, estimates total CPU via P50 × requests (#93)
+- Fingerprint normaliser regex ordering — timestamps now normalised before numeric IDs, preventing `\d{4,}` from destroying the year component first (#94)
+- Fingerprint normaliser hex ID threshold lowered from 24 to 8 chars — catches short correlationIds like Brand Copilot's 8-char hex suffixes (#95)
+- Custom `transient_patterns` from `cf-monitor.yaml` were parsed but never consumed by the pattern matcher — now fully wired into `matchTransientPattern()` and `getTransientPatternName()` (#96)
+- Soft errors (`console.error()` from ok-outcome events) bypassed transient dedup — `processLogEntry()` now uses per-pattern daily dedup matching `processEvent()` behaviour (#99)
+- Same-batch burst race condition — 4 identical Gemini 503s in one tail batch created 4 issues instead of 1; added in-memory `Set<string>` batch-level dedup that eliminates duplicate fingerprints within a single tail invocation (#99)
+- Fingerprint normaliser fails on JSON structured logs — variable fields (`correlationId`, `duration_ms`, `totalAttempts`) embedded in JSON produce unique hashes; now extracts the `"message"` field from JSON strings before fingerprinting, plus normalises JSON-embedded small numbers (1-3 digits) (#92)
+
+### Added
+- Built-in `billing-exhausted` transient pattern — matches `402`, `insufficient balance`, `payment required` for DeepSeek/OpenAI billing errors (#97)
+- Daily issue cap of 50 per script per day (`MAX_ISSUES_PER_SCRIPT_PER_DAY`) — prevents sustained error floods that bypass the 10/hour rate limit (#98)
+- 22 new unit tests covering all fixes (338 total, up from 316)
+
+### Changed
+- `matchTransientPattern()` and `getTransientPatternName()` accept optional `customPatterns` parameter — backward compatible, no breaking changes
+- `handleTailEvents()`, `processEvent()`, and `processLogEntry()` now pass a shared `batchSeen: Set<string>` for in-memory dedup
+- GraphQL CPU metric is now an estimate (`cpuTimeP50 × requests / 1000`) rather than an exact sum — CF removed the summable `cpuTime` field
 
 ## [0.3.7] - 2026-03-31
 
@@ -205,7 +224,8 @@ All notable changes to cf-monitor are documented here. This project follows [Kee
 - CI pipeline: Node 20/22 matrix, publint, attw, lockfile-lint, package validation
 - Release workflow: tag-triggered npm publish
 
-[Unreleased]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.7...HEAD
+[Unreleased]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.8...HEAD
+[0.3.8]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/littlebearapps/cf-monitor/compare/v0.3.4...v0.3.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - cf-monitor
 
-**Last Updated**: 2026-03-31
+**Last Updated**: 2026-04-15
 
 ---
 
@@ -38,7 +38,7 @@
 | **Language** | TypeScript |
 | **Runtime** | Cloudflare Workers |
 | **npm** | `@littlebearapps/cf-monitor` |
-| **Status** | v0.3.7 — production-tested, published to npm |
+| **Status** | v0.3.8 — production-tested, published to npm |
 | **Repository** | https://github.com/littlebearapps/cf-monitor |
 | **Licence** | MIT |
 | **Issues** | https://github.com/littlebearapps/cf-monitor/issues |
@@ -321,7 +321,25 @@ Full security audit with 9 fixes:
 
 ---
 
-## Stubs & Partial Features (v0.3.7)
+## Bug Fixes (v0.3.8)
+
+**#92 — JSON message extraction in fingerprint**: FIXED. `normaliseMessage()` now extracts the `"message"` field from JSON structured logs before fingerprinting. Also normalises JSON-embedded small numbers (1-3 digits). Prevents variable metadata (`correlationId`, `duration_ms`, `totalAttempts`) from producing unique hashes for identical errors.
+
+**#93 — cpuTime GraphQL field removed**: FIXED. Cloudflare removed `cpuTime` from `sum` selection. Both `collect-account-usage.ts` and `collect-metrics.ts` now use `quantiles { cpuTimeP50 }` and estimate total CPU as `P50 * requests / 1000`. Data is approximate but consistent.
+
+**#94 — Regex ordering in normaliseMessage**: FIXED. Timestamp regex now runs before `\d{4,}` numeric ID regex, preventing the year component from being stripped first.
+
+**#95 — Hex ID threshold too high**: FIXED. Lowered from 24 to 8 chars. Catches short correlationIds like Brand Copilot's 8-char hex suffixes.
+
+**#96 — Custom transient_patterns wired**: FIXED. `transient_patterns:` array in `cf-monitor.yaml` is now consumed by `matchTransientPattern()` and `getTransientPatternName()`. Custom patterns checked after the 9 built-in patterns.
+
+**#97 — billing-exhausted transient pattern**: ADDED. New 9th built-in pattern matches `402`, `insufficient balance`, `payment required`. Catches DeepSeek/OpenAI billing errors.
+
+**#98 — Daily issue cap**: ADDED. `MAX_ISSUES_PER_SCRIPT_PER_DAY = 50` enforced in both `processEvent` and `processLogEntry`. Prevents sustained error floods (previously 10/hour could accumulate to 240/day).
+
+**#99 — Soft error transient dedup + batch dedup**: FIXED. (1) `processLogEntry()` now uses transient dedup with per-pattern daily keys (`err:transient:{script}:soft_error:{pattern}:{date}`). (2) In-memory `Set<string>` tracks fingerprints within each tail batch, eliminating same-batch race conditions (the BC #1228 scenario where 4 Gemini 503s in one batch created 4 separate issues).
+
+## Stubs & Partial Features (v0.3.8)
 
 Config surfaces exist for these, but the wiring is incomplete. If you're asked to use any of these, implement the missing integration first and flag the gap to the user:
 
@@ -330,10 +348,9 @@ Config surfaces exist for these, but the wiring is incomplete. If you're asked t
 | AI pattern discovery | `ai.pattern_discovery` in `cf-monitor.yaml` | `src/worker/optional/pattern-discovery.ts` is a `console.log()` TODO stub. Issue #8. |
 | AI health reports | `ai.health_reports` | `src/worker/optional/health-reporter.ts` is a stub. Issue #9. |
 | AI coverage auditor | `ai.coverage_auditor` | `src/worker/optional/coverage-auditor.ts` is a stub. Issue #10. |
-| Custom transient patterns | `transient_patterns:` array | Parses to `env._customTransientPatterns` but `src/worker/errors/patterns.ts` matcher only consults the 8 built-ins. Issue #92. |
 | Configurable spike threshold | `monitoring.spike_threshold` | Schema validates `≥ 1.5`, but `src/worker/crons/cost-spike.ts:7` hardcodes `const SPIKE_THRESHOLD = 2.0`. |
 
-Docs reflect these gaps as of 2026-04-13 — see `README.md`, `docs/configuration.md`, `docs/guides/error-collection.md`, `docs/guides/cost-spike-detection.md`.
+Docs reflect these gaps as of 2026-04-15 — see `README.md`, `docs/configuration.md`, `docs/guides/cost-spike-detection.md`.
 
 ## Open Work
 
@@ -341,4 +358,3 @@ See https://github.com/littlebearapps/cf-monitor/issues for planned features.
 
 **Remaining features:**
 - #8, #9, #10 — AI optional features (pattern discovery, health reports, coverage auditor) — stubs created in `src/worker/optional/`
-- #92 — Wire custom `transient_patterns` into `matchTransientPattern()`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ That's it. Worker name, feature IDs, bindings, and budgets are all auto-detected
 
 ### Optional (AI-powered, disabled by default)
 
-> 🚧 **Not yet implemented in v0.3.7.** The YAML keys exist and parse, but the cron handlers are stubs (`src/worker/optional/*.ts`). Enabling them is a no-op. Tracked in issues [#8](https://github.com/littlebearapps/cf-monitor/issues/8), [#9](https://github.com/littlebearapps/cf-monitor/issues/9), [#10](https://github.com/littlebearapps/cf-monitor/issues/10).
+> 🚧 **Not yet implemented in v0.3.8.** The YAML keys exist and parse, but the cron handlers are stubs (`src/worker/optional/*.ts`). Enabling them is a no-op. Tracked in issues [#8](https://github.com/littlebearapps/cf-monitor/issues/8), [#9](https://github.com/littlebearapps/cf-monitor/issues/9), [#10](https://github.com/littlebearapps/cf-monitor/issues/10).
 
 - 🤖 **Pattern discovery** — AI detection of transient error patterns (planned)
 - 📝 **Health reports** — natural language account health summaries (planned)

--- a/cf-monitor.schema.json
+++ b/cf-monitor.schema.json
@@ -96,7 +96,7 @@
           "type": "number",
           "minimum": 1.5,
           "default": 2.0,
-          "description": "Cost spike alert threshold (multiplier above baseline). NOT YET WIRED in v0.3.7 — src/worker/crons/cost-spike.ts hardcodes 2.0. Values set here are ignored."
+          "description": "Cost spike alert threshold (multiplier above baseline). NOT YET WIRED in v0.3.8 — src/worker/crons/cost-spike.ts hardcodes 2.0. Values set here are ignored."
         }
       }
     },
@@ -134,27 +134,27 @@
     },
     "ai": {
       "type": "object",
-      "description": "Optional AI-powered features. NOT YET IMPLEMENTED in v0.3.7 — handlers in src/worker/optional/ are stubs. Enabling these flags is a no-op. Tracked in issues #8, #9, #10.",
+      "description": "Optional AI-powered features. NOT YET IMPLEMENTED in v0.3.8 — handlers in src/worker/optional/ are stubs. Enabling these flags is a no-op. Tracked in issues #8, #9, #10.",
       "properties": {
         "enabled": {
           "type": "boolean",
           "default": false,
-          "description": "Enable AI features globally. STUB — no effect in v0.3.7."
+          "description": "Enable AI features globally. STUB — no effect in v0.3.8."
         },
         "pattern_discovery": {
           "type": "boolean",
           "default": false,
-          "description": "Enable AI-powered transient error pattern discovery. STUB — no effect in v0.3.7 (issue #8)."
+          "description": "Enable AI-powered transient error pattern discovery. STUB — no effect in v0.3.8 (issue #8)."
         },
         "health_reports": {
           "type": "boolean",
           "default": false,
-          "description": "Enable AI-generated health report summaries. STUB — no effect in v0.3.7 (issue #9)."
+          "description": "Enable AI-generated health report summaries. STUB — no effect in v0.3.8 (issue #9)."
         },
         "coverage_auditor": {
           "type": "boolean",
           "default": false,
-          "description": "Enable AI-powered SDK coverage auditing. STUB — no effect in v0.3.7 (issue #10)."
+          "description": "Enable AI-powered SDK coverage auditing. STUB — no effect in v0.3.8 (issue #10)."
         },
         "model": {
           "type": "string",
@@ -165,7 +165,7 @@
     },
     "transient_patterns": {
       "type": "array",
-      "description": "Custom transient error patterns for deduplication. PARTIAL — config loads into env._customTransientPatterns but matcher only checks built-ins in v0.3.7 (issue #92). Safe to define now; will activate when matcher integration lands.",
+      "description": "Custom transient error patterns for deduplication. Patterns are checked after the 9 built-in patterns. Matching errors get 1-issue-per-pattern-per-day dedup.",
       "items": {
         "type": "object",
         "properties": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ Step-by-step instructions for specific tasks:
 
 - [Security](./security.md) — admin auth, secrets, threat model, data exposure, SDK security
 - [Troubleshooting](./troubleshooting.md) — 14 common issues with solutions
-- [Changelog](../CHANGELOG.md) — version history (v0.1.0 to v0.3.7)
+- [Changelog](../CHANGELOG.md) — version history (v0.1.0 to v0.3.8)
 
 ## Internal Reports
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,10 +56,10 @@ monitoring:
   gap_detection_minutes: 15                 # How often to check for gaps (5-60, default 15)
   heartbeat_url: "https://..."              # Gatus/uptime monitor heartbeat URL
   heartbeat_token: $GATUS_TOKEN             # Bearer token for heartbeat
-  spike_threshold: 2.0                      # ⚠️ Not yet wired in v0.3.7 — see below
+  spike_threshold: 2.0                      # ⚠️ Not yet wired in v0.3.8 — see below
 ```
 
-> 🚧 **`spike_threshold` is config-only in v0.3.7.** The YAML key parses and the schema validates, but `src/worker/crons/cost-spike.ts` hardcodes the threshold to `2.0`. Values you set here are ignored until this is wired up. See [Cost spike detection](./guides/cost-spike-detection.md) for details.
+> 🚧 **`spike_threshold` is config-only in v0.3.8.** The YAML key parses and the schema validates, but `src/worker/crons/cost-spike.ts` hardcodes the threshold to `2.0`. Values you set here are ignored until this is wired up. See [Cost spike detection](./guides/cost-spike-detection.md) for details.
 
 Also see [Gatus heartbeat](./how-to/gatus-heartbeat.md) for `heartbeat_url` / `heartbeat_token` setup end-to-end.
 
@@ -123,11 +123,11 @@ exclude:
 
 ### ai (optional)
 
-> 🚧 **Not yet implemented in v0.3.7.** The keys below parse and validate, but the cron handlers in `src/worker/optional/` are stubs that log "TODO" and return. Enabling these flags is a no-op. Tracked: [#8](https://github.com/littlebearapps/cf-monitor/issues/8) pattern discovery, [#9](https://github.com/littlebearapps/cf-monitor/issues/9) health reports, [#10](https://github.com/littlebearapps/cf-monitor/issues/10) coverage auditor.
+> 🚧 **Not yet implemented in v0.3.8.** The keys below parse and validate, but the cron handlers in `src/worker/optional/` are stubs that log "TODO" and return. Enabling these flags is a no-op. Tracked: [#8](https://github.com/littlebearapps/cf-monitor/issues/8) pattern discovery, [#9](https://github.com/littlebearapps/cf-monitor/issues/9) health reports, [#10](https://github.com/littlebearapps/cf-monitor/issues/10) coverage auditor.
 
 ```yaml
 ai:
-  enabled: false                            # Master switch for AI features (no-op in v0.3.7)
+  enabled: false                            # Master switch for AI features (no-op in v0.3.8)
   pattern_discovery: false                  # AI error pattern detection (stub)
   health_reports: false                     # Natural language health summaries (stub)
   coverage_auditor: false                   # AI integration scoring (stub)
@@ -138,7 +138,7 @@ AI features are disabled by default and will require explicit opt-in once implem
 
 ### transient_patterns (optional)
 
-> 🚧 **Configured but not yet applied in v0.3.7.** The YAML key is parsed and the values are loaded into `env._customTransientPatterns`, but `matchTransientPattern()` in `src/worker/errors/patterns.ts` only checks the 8 built-in patterns — user-supplied patterns are silently ignored. Tracked in [#92](https://github.com/littlebearapps/cf-monitor/issues/92). The 8 built-in patterns (`rate-limited`, `timeout`, `quota-exhausted`, `connection-refused`, `dns-failure`, `service-unavailable`, `cf-internal`) are active and work correctly.
+Define custom transient error patterns to supplement the 9 built-in patterns (`rate-limited`, `timeout`, `quota-exhausted`, `connection-refused`, `dns-failure`, `service-unavailable`, `cf-internal`, `billing-exhausted`). Matching errors are deduplicated to one GitHub issue per pattern per day.
 
 ```yaml
 transient_patterns:
@@ -148,7 +148,7 @@ transient_patterns:
     match: "connection pool"
 ```
 
-Once wired up, matching errors will be deduplicated to one GitHub issue per category per day, as with the built-ins.
+Each pattern requires a `name` (used in dedup keys) and a `match` (regex pattern, case-insensitive). Built-in patterns are checked first — custom patterns serve as supplementary matchers for domain-specific transient errors.
 
 ---
 

--- a/docs/guides/budgets-and-circuit-breakers.md
+++ b/docs/guides/budgets-and-circuit-breakers.md
@@ -160,7 +160,7 @@ The 15-minute cron (`*/15 * * * *`) compares current hourly costs against a 24-h
 
 This catches anomalies that fall within budget limits but are still unusual — like a worker suddenly doing 10x more D1 reads than normal.
 
-> 🚧 **The threshold is not yet configurable in v0.3.7.** `cf-monitor.yaml` accepts `monitoring.spike_threshold`, but `src/worker/crons/cost-spike.ts` hardcodes it to `2.0`. See [Cost spike detection](./cost-spike-detection.md) for full details, tuning workarounds, and alert shape.
+> 🚧 **The threshold is not yet configurable in v0.3.8.** `cf-monitor.yaml` accepts `monitoring.spike_threshold`, but `src/worker/crons/cost-spike.ts` hardcodes it to `2.0`. See [Cost spike detection](./cost-spike-detection.md) for full details, tuning workarounds, and alert shape.
 
 ## Synthetic health checks (Validation layer)
 

--- a/docs/guides/cost-spike-detection.md
+++ b/docs/guides/cost-spike-detection.md
@@ -35,10 +35,10 @@ If `CLOUDFLARE_API_TOKEN` or `CF_ACCOUNT_ID` is missing, the handler exits early
 
 ## Tuning the threshold
 
-> 🚧 **Config key exists but is not yet wired in v0.3.7.** `cf-monitor.yaml` accepts `monitoring.spike_threshold` and the schema validates it (range ≥ 1.5, default 2.0), but `src/worker/crons/cost-spike.ts:7` hardcodes `const SPIKE_THRESHOLD = 2.0;`. Values you set in YAML are currently ignored.
+> 🚧 **Config key exists but is not yet wired in v0.3.8.** `cf-monitor.yaml` accepts `monitoring.spike_threshold` and the schema validates it (range ≥ 1.5, default 2.0), but `src/worker/crons/cost-spike.ts:7` hardcodes `const SPIKE_THRESHOLD = 2.0;`. Values you set in YAML are currently ignored.
 
 ```yaml
-# cf-monitor.yaml — parses but has no effect in v0.3.7
+# cf-monitor.yaml — parses but has no effect in v0.3.8
 monitoring:
   spike_threshold: 3.0    # Intended: 300% of baseline before alerting
 ```

--- a/docs/guides/error-collection.md
+++ b/docs/guides/error-collection.md
@@ -63,9 +63,11 @@ fingerprint = FNV-hash( scriptName + ":" + outcome + ":" + normalise(message) )
 Before hashing, error messages are normalised to strip variable content:
 
 - **UUIDs** → `<UUID>` (e.g. `abc123de-f456-7890-1234-56780cdef012`)
-- **Hex IDs** (24+ chars) → `<ID>`
+- **JSON message extraction** — if the message starts with `{`, the `"message"` field is extracted for fingerprinting (strips variable metadata like `correlationId`, `duration_ms`)
+- **Hex IDs** (8+ chars) → `<ID>` (catches correlationIds, MongoDB ObjectIds, etc.)
 - **Numeric IDs** (4+ digits) → `<N>`
-- **Timestamps** → `<TS>` (ISO 8601 format)
+- **Timestamps** → `<TS>` (ISO 8601 format — processed before numeric IDs to prevent year stripping)
+- **JSON small numbers** (1-3 digits after `:`) → `<N>` (catches `"attempt": 4`, `"totalAttempts": 2`)
 - **IP addresses** → `<IP>`
 - Whitespace is collapsed and the message is truncated to 200 characters
 
@@ -73,16 +75,18 @@ This means the same logical error with different IDs, timestamps, or request-spe
 
 ## Deduplication layers
 
-cf-monitor uses four layers to prevent duplicate issues:
+cf-monitor uses six layers to prevent duplicate issues:
 
-1. **Fingerprint lookup** — checks KV for `err:fp:{hash}`. If found, the error already has a GitHub issue. (90-day TTL)
-2. **Rate limit** — max 10 issues per script per hour via `err:rate:{script}:{hour}`. Prevents issue floods from cascading failures.
-3. **Transient dedup** — known transient errors (rate limits, timeouts) get max 1 issue per category per day via `err:transient:{script}:{category}:{date}`.
-4. **Lock** — 60-second KV lock via `err:lock:{fingerprint}` prevents race conditions when multiple tail events arrive simultaneously.
+1. **Batch dedup** — in-memory `Set<string>` tracks fingerprints within a single tail invocation. Eliminates same-batch duplicates with zero latency (no KV round-trip).
+2. **Fingerprint lookup** — checks KV for `err:fp:{hash}`. If found, the error already has a GitHub issue. (90-day TTL)
+3. **Rate limit** — max 10 issues per script per hour via `err:rate:{script}:{hour}`. Prevents issue floods from cascading failures.
+4. **Daily cap** — max 50 issues per script per day via `err:rate:{script}:daily:{date}`. Hard ceiling on sustained floods.
+5. **Transient dedup** — known transient errors (rate limits, timeouts, billing errors) get max 1 issue per category per day via `err:transient:{script}:{category}:{date}`. Works for both hard errors and soft errors (`console.error()`).
+6. **Lock** — 60-second KV lock via `err:lock:{fingerprint}` prevents race conditions across concurrent tail invocations.
 
 ## Transient error patterns
 
-cf-monitor recognises 8 built-in transient patterns and limits them to one issue per category per day:
+cf-monitor recognises 9 built-in transient patterns and limits them to one issue per category per day:
 
 | Pattern | Matches |
 |---------|---------|
@@ -93,8 +97,9 @@ cf-monitor recognises 8 built-in transient patterns and limits them to one issue
 | `dns-failure` | "ENOTFOUND", "DNS failed", "getaddrinfo" |
 | `service-unavailable` | "503", "502", canceled outcome, stream disconnected |
 | `cf-internal` | "internal error" + "cloudflare" |
+| `billing-exhausted` | "insufficient balance", "402", "payment required" |
 
-### Custom transient patterns (v0.3.7: config-only)
+### Custom transient patterns
 
 `cf-monitor.yaml` accepts a `transient_patterns:` array for your own categories:
 
@@ -102,9 +107,11 @@ cf-monitor recognises 8 built-in transient patterns and limits them to one issue
 transient_patterns:
   - name: "custom-gateway-timeout"
     match: "504 gateway timeout"
+  - name: "db-pool-exhausted"
+    match: "connection pool"
 ```
 
-> 🚧 **Not yet applied at runtime.** In v0.3.7, the matcher in `src/worker/errors/patterns.ts` only consults the 8 built-ins — custom entries are parsed and loaded onto `env._customTransientPatterns` but never consulted. Tracked in [#92](https://github.com/littlebearapps/cf-monitor/issues/92). Patterns you define now will activate automatically once the matcher integration ships.
+Custom patterns are checked after the built-in patterns. Each requires a `name` (used in dedup keys) and `match` (regex, case-insensitive). Matching errors get the same 1-issue-per-day dedup as built-ins.
 
 ## GitHub issues
 

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ cf-monitor wraps Cloudflare Workers with a single `monitor()` call, tracks every
 - [Configuration Reference](https://github.com/littlebearapps/cf-monitor/blob/main/docs/configuration.md): All cf-monitor.yaml and MonitorConfig SDK options
 - [Security](https://github.com/littlebearapps/cf-monitor/blob/main/docs/security.md): Admin auth, secrets, threat model, data exposure
 - [Troubleshooting](https://github.com/littlebearapps/cf-monitor/blob/main/docs/troubleshooting.md): 16 common issues with solutions
-- [Changelog](https://github.com/littlebearapps/cf-monitor/blob/main/CHANGELOG.md): Version history v0.1.0 to v0.3.7
+- [Changelog](https://github.com/littlebearapps/cf-monitor/blob/main/CHANGELOG.md): Version history v0.1.0 to v0.3.8
 - [Contributing](https://github.com/littlebearapps/cf-monitor/blob/main/CONTRIBUTING.md): Development setup and conventions
 
 ## Guides
@@ -34,8 +34,7 @@ cf-monitor wraps Cloudflare Workers with a single `monitor()` call, tracks every
 - [Gatus Heartbeat](https://github.com/littlebearapps/cf-monitor/blob/main/docs/how-to/gatus-heartbeat.md): External uptime monitor for cf-monitor crons
 - [Custom Feature IDs](https://github.com/littlebearapps/cf-monitor/blob/main/docs/how-to/custom-feature-ids.md): featureId, featurePrefix, features map
 
-## Stubs & Partial Features (v0.3.7)
+## Stubs & Partial Features (v0.3.8)
 
 - AI features (pattern discovery, health reports, coverage auditor) — `src/worker/optional/*.ts` are stubs. Enabling `ai.*` flags is a no-op. Issues #8, #9, #10.
-- `transient_patterns:` YAML key — parses but matcher only consults built-ins. Issue #92.
 - `monitoring.spike_threshold` YAML key — schema validates but hardcoded to 2.0 in source.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/cf-monitor",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Self-contained Cloudflare account monitoring: error collection, feature budgets, circuit breakers, cost protection. One worker per account.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -181,6 +181,9 @@ export const CAPTURABLE_OUTCOMES: ReadonlySet<string> = new Set([
 /** Max GitHub issues created per script per hour. */
 export const MAX_ISSUES_PER_SCRIPT_PER_HOUR = 10;
 
+/** Max GitHub issues created per script per day (#92). */
+export const MAX_ISSUES_PER_SCRIPT_PER_DAY = 50;
+
 /** Error priority thresholds. */
 export const PRIORITY_MAP: Record<string, string> = {
 	exception: 'P1',

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,6 +184,8 @@ export interface MonitorWorkerEnv {
 	ADMIN_TOKEN?: string;
 	GITHUB_WEBHOOK_SECRET?: string;
 	AI?: Ai;
+	/** Custom transient patterns resolved from cf-monitor.yaml (#92). */
+	_customTransientPatterns?: CustomTransientPattern[];
 }
 
 // =============================================================================
@@ -275,6 +277,12 @@ export interface TelemetryDataPoint {
 // CONFIG (cf-monitor.yaml)
 // =============================================================================
 
+/** Custom transient pattern from cf-monitor.yaml (#92). */
+export interface CustomTransientPattern {
+	name: string;
+	match: string;
+}
+
 export interface CfMonitorConfig {
 	account: {
 		name: string;
@@ -302,6 +310,8 @@ export interface CfMonitorConfig {
 		health_reports?: boolean;
 		model?: string;
 	};
+	/** Custom transient patterns — errors matching these get daily dedup instead of per-event (#92). */
+	transient_patterns?: CustomTransientPattern[];
 	exclude?: string[];
 }
 

--- a/src/worker/config.ts
+++ b/src/worker/config.ts
@@ -1,4 +1,4 @@
-import type { MonitorWorkerEnv } from '../types.js';
+import type { CustomTransientPattern, MonitorWorkerEnv } from '../types.js';
 
 /**
  * Runtime config parser.
@@ -42,6 +42,8 @@ export interface ResolvedConfig {
 		coverage_auditor?: boolean;
 		model?: string;
 	};
+	/** Custom transient patterns from cf-monitor.yaml (#92). */
+	transient_patterns?: CustomTransientPattern[];
 }
 
 /**
@@ -98,6 +100,11 @@ export function enrichEnv(env: MonitorWorkerEnv): MonitorWorkerEnv {
 		) {
 			(enriched as Record<string, unknown>)[key] = value;
 		}
+	}
+
+	// Pass custom transient patterns to tail handler (#92)
+	if (Array.isArray(config.transient_patterns) && config.transient_patterns.length > 0) {
+		enriched._customTransientPatterns = config.transient_patterns;
 	}
 
 	return enriched;

--- a/src/worker/crons/collect-account-usage.ts
+++ b/src/worker/crons/collect-account-usage.ts
@@ -80,7 +80,8 @@ async function queryCoreServices(
 	const [workersResult, d1Result, kvResult, r2Result] = await Promise.all([
 		executeGraphQL(env, `{ viewer { accounts(filter: { ${accountFilter} }) {
 			workersInvocationsAdaptive(filter: { datetime_geq: "${startDatetime}", datetime_lt: "${endDatetime}" }, limit: 1000) {
-				sum { requests cpuTime }
+				sum { requests }
+				quantiles { cpuTimeP50 }
 			}
 		} } }`),
 		executeGraphQL(env, `{ viewer { accounts(filter: { ${accountFilter} }) {
@@ -102,17 +103,18 @@ async function queryCoreServices(
 		} } }`),
 	]);
 
-	// Workers
+	// Workers — cpuTime removed from sum by CF, estimate via P50 * requests (#93)
 	try {
 		const workers = workersResult?.data?.viewer?.accounts?.[0]?.workersInvocationsAdaptive;
 		if (workers?.length) {
 			let totalRequests = 0;
-			let totalCpuUs = 0;
+			let estimatedCpuUs = 0;
 			for (const w of workers) {
-				totalRequests += w.sum?.requests ?? 0;
-				totalCpuUs += w.sum?.cpuTime ?? 0;
+				const requests = w.sum?.requests ?? 0;
+				totalRequests += requests;
+				estimatedCpuUs += (w.quantiles?.cpuTimeP50 ?? 0) * requests;
 			}
-			const totalCpuMs = Math.round(totalCpuUs / 1000);
+			const totalCpuMs = Math.round(estimatedCpuUs / 1000);
 			services.workers = { requests: totalRequests, cpuMs: totalCpuMs };
 		}
 	} catch { /* skip */ }

--- a/src/worker/crons/collect-metrics.ts
+++ b/src/worker/crons/collect-metrics.ts
@@ -79,7 +79,9 @@ function buildGraphQLQuery(accountId: string, start: Date, end: Date): string {
           requests
           errors
           subrequests
-          cpuTime
+        }
+        quantiles {
+          cpuTimeP50
         }
       }
       d1AnalyticsAdaptiveGroups(
@@ -121,7 +123,8 @@ interface GraphQLResponse {
 			accounts: Array<{
 				workersInvocationsAdaptive?: Array<{
 					dimensions: { scriptName: string };
-					sum: { requests: number; errors: number; subrequests: number; cpuTime: number };
+					sum: { requests: number; errors: number; subrequests: number };
+					quantiles?: { cpuTimeP50: number };
 				}>;
 				d1AnalyticsAdaptiveGroups?: Array<{
 					sum: { readQueries: number; writeQueries: number; rowsRead: number; rowsWritten: number };
@@ -148,7 +151,7 @@ function writeMetricsToAE(env: MonitorWorkerEnv, data: GraphQLResponse): void {
 			blobs: [worker.dimensions.scriptName, 'graphql', 'workers'],
 			doubles: [
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				worker.sum.requests, Math.round(worker.sum.cpuTime / 1000),
+				worker.sum.requests, Math.round(((worker.quantiles?.cpuTimeP50 ?? 0) * worker.sum.requests) / 1000),
 				0, 0, 0, 0, 0, 0, 0, 0,
 			],
 			indexes: [`${worker.dimensions.scriptName}:graphql:workers`],

--- a/src/worker/errors/fingerprint.ts
+++ b/src/worker/errors/fingerprint.ts
@@ -19,15 +19,31 @@ export function computeFingerprint(scriptName: string, outcome: string, message:
  * Normalise an error message by stripping variable content.
  */
 function normaliseMessage(message: string): string {
-	return message
+	let msg = message;
+
+	// JSON structured logs: extract inner "message" field for fingerprinting (#92)
+	if (msg.startsWith('{')) {
+		try {
+			const parsed = JSON.parse(msg);
+			if (typeof parsed.message === 'string' && parsed.message.length > 0) {
+				msg = parsed.message;
+			}
+		} catch {
+			// Not valid JSON (possibly truncated) — continue with original
+		}
+	}
+
+	return msg
 		// Strip UUIDs
 		.replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '<UUID>')
-		// Strip hex IDs (24+ chars)
-		.replace(/\b[0-9a-f]{24,}\b/gi, '<ID>')
-		// Strip numeric IDs
-		.replace(/\b\d{4,}\b/g, '<N>')
-		// Strip timestamps
+		// Strip timestamps BEFORE numeric IDs — \d{4,} would destroy the year (#94)
 		.replace(/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}[.\dZ]*/g, '<TS>')
+		// Strip hex IDs (8+ chars — catches correlationIds, not just MongoDB ObjectIds)
+		.replace(/\b[0-9a-f]{8,}\b/gi, '<ID>')
+		// Strip numeric IDs (4+ digits)
+		.replace(/\b\d{4,}\b/g, '<N>')
+		// Strip JSON-embedded small numbers (1-3 digits after colon) (#92)
+		.replace(/":\s*\d{1,3}([,}\]])/g, '": <N>$1')
 		// Strip IP addresses
 		.replace(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/g, '<IP>')
 		// Collapse whitespace

--- a/src/worker/errors/patterns.ts
+++ b/src/worker/errors/patterns.ts
@@ -1,10 +1,12 @@
 /**
- * Static transient error patterns.
+ * Transient error patterns — static + custom from cf-monitor.yaml.
  *
  * These patterns identify errors that are expected to be temporary
  * (rate limits, timeouts, quotas) and should be deduplicated
  * to one issue per category per day.
  */
+
+import type { CustomTransientPattern } from '../../types.js';
 
 interface TransientPattern {
 	/** Pattern name for dedup key */
@@ -63,21 +65,42 @@ const TRANSIENT_PATTERNS: TransientPattern[] = [
 			/internal error/i.test(msg) &&
 			/cloudflare/i.test(msg),
 	},
+	{
+		name: 'billing-exhausted',
+		test: (msg) =>
+			/insufficient.*balance/i.test(msg) ||
+			/402\b/.test(msg) ||
+			/payment.*required/i.test(msg),
+	},
 ];
 
 /**
  * Check if an error message matches a known transient pattern.
  * Returns true if the error should be rate-limited to one issue per day.
+ * Accepts optional custom patterns from cf-monitor.yaml (#92).
  */
-export function matchTransientPattern(message: string, outcome: string): boolean {
-	return TRANSIENT_PATTERNS.some((p) => p.test(message, outcome));
+export function matchTransientPattern(
+	message: string,
+	outcome: string,
+	customPatterns?: CustomTransientPattern[]
+): boolean {
+	if (TRANSIENT_PATTERNS.some((p) => p.test(message, outcome))) return true;
+	if (customPatterns?.some((p) => new RegExp(p.match, 'i').test(message))) return true;
+	return false;
 }
 
 /**
  * Get the transient pattern name for an error (for dedup keys).
  * Returns null if not transient.
+ * Accepts optional custom patterns from cf-monitor.yaml (#92).
  */
-export function getTransientPatternName(message: string, outcome: string): string | null {
-	const match = TRANSIENT_PATTERNS.find((p) => p.test(message, outcome));
-	return match?.name ?? null;
+export function getTransientPatternName(
+	message: string,
+	outcome: string,
+	customPatterns?: CustomTransientPattern[]
+): string | null {
+	const builtIn = TRANSIENT_PATTERNS.find((p) => p.test(message, outcome));
+	if (builtIn) return builtIn.name;
+	const custom = customPatterns?.find((p) => new RegExp(p.match, 'i').test(message));
+	return custom?.name ?? null;
 }

--- a/src/worker/tail-handler.ts
+++ b/src/worker/tail-handler.ts
@@ -1,7 +1,7 @@
-import { CAPTURABLE_OUTCOMES, KV, MAX_ISSUES_PER_SCRIPT_PER_HOUR, PRIORITY_MAP } from '../constants.js';
+import { CAPTURABLE_OUTCOMES, KV, MAX_ISSUES_PER_SCRIPT_PER_DAY, MAX_ISSUES_PER_SCRIPT_PER_HOUR, PRIORITY_MAP } from '../constants.js';
 import type { MonitorWorkerEnv, TailOutcome } from '../types.js';
 import { computeFingerprint } from './errors/fingerprint.js';
-import { matchTransientPattern } from './errors/patterns.js';
+import { getTransientPatternName, matchTransientPattern } from './errors/patterns.js';
 import { createGitHubIssue } from './errors/github.js';
 import { recordSelfTelemetry, recordHandlerError } from './self-monitor.js';
 
@@ -16,9 +16,11 @@ export async function handleTailEvents(
 ): Promise<void> {
 	const start = Date.now();
 	let errorCount = 0;
+	// In-memory dedup prevents same-batch race condition (#99 — #1228 burst scenario)
+	const batchSeen = new Set<string>();
 	for (const event of events) {
 		try {
-			await processEvent(event, env);
+			await processEvent(event, env, batchSeen);
 		} catch (err) {
 			// Never let one event failure break the batch
 			errorCount++;
@@ -40,13 +42,13 @@ export async function handleTailEvents(
 	}
 }
 
-async function processEvent(event: TraceItem, env: MonitorWorkerEnv): Promise<void> {
+async function processEvent(event: TraceItem, env: MonitorWorkerEnv, batchSeen: Set<string>): Promise<void> {
 	const scriptName = event.scriptName ?? 'unknown';
 	const outcome = event.outcome as string;
 
 	// For ok outcomes, scan logs for soft errors and warnings (#14)
 	if (outcome === 'ok') {
-		await processSoftErrors(event, env, scriptName);
+		await processSoftErrors(event, env, scriptName, batchSeen);
 		return;
 	}
 
@@ -61,8 +63,15 @@ async function processEvent(event: TraceItem, env: MonitorWorkerEnv): Promise<vo
 	const priority = PRIORITY_MAP[outcome] ?? 'P3';
 	const fingerprint = computeFingerprint(scriptName, outcome, errorInfo.message);
 
+	// Batch-level dedup: skip if already processed in this tail invocation (#99)
+	if (batchSeen.has(fingerprint)) {
+		console.log(`[cf-monitor:tail] Batch dedup: ${scriptName}:${outcome} fp=${fingerprint}`);
+		return;
+	}
+	batchSeen.add(fingerprint);
+
 	// Check if this is a transient pattern (rate-limited, timeout, etc.)
-	const isTransient = matchTransientPattern(errorInfo.message, outcome);
+	const isTransient = matchTransientPattern(errorInfo.message, outcome, env._customTransientPatterns);
 
 	// Dedup: check if we already have a GitHub issue for this fingerprint
 	const existingIssueUrl = await env.CF_MONITOR_KV.get(`${KV.ERR_FINGERPRINT}${fingerprint}`);
@@ -76,6 +85,14 @@ async function processEvent(event: TraceItem, env: MonitorWorkerEnv): Promise<vo
 	const currentRate = parseInt(await env.CF_MONITOR_KV.get(rateLimitKey) ?? '0', 10);
 	if (currentRate >= MAX_ISSUES_PER_SCRIPT_PER_HOUR) {
 		console.log(`[cf-monitor:tail] Rate limit: ${scriptName} at ${currentRate}/${MAX_ISSUES_PER_SCRIPT_PER_HOUR}/hr`);
+		return;
+	}
+
+	// Daily cap: max N issues per script per day (#92)
+	const dailyRateKey = `${KV.ERR_RATE}${scriptName}:daily:${currentDate()}`;
+	const dailyRate = parseInt(await env.CF_MONITOR_KV.get(dailyRateKey) ?? '0', 10);
+	if (dailyRate >= MAX_ISSUES_PER_SCRIPT_PER_DAY) {
+		console.log(`[cf-monitor:tail] Daily cap: ${scriptName} at ${dailyRate}/${MAX_ISSUES_PER_SCRIPT_PER_DAY}/day`);
 		return;
 	}
 
@@ -127,8 +144,9 @@ async function processEvent(event: TraceItem, env: MonitorWorkerEnv): Promise<vo
 		console.warn(`[cf-monitor:tail] GitHub not configured (GITHUB_REPO=${!!env.GITHUB_REPO}, GITHUB_TOKEN=${!!env.GITHUB_TOKEN}) — skipping issue for ${scriptName}:${outcome}`);
 	}
 
-	// Increment rate counter
+	// Increment rate counters
 	await env.CF_MONITOR_KV.put(rateLimitKey, String(currentRate + 1), { expirationTtl: 7200 }); // 2hr
+	await env.CF_MONITOR_KV.put(dailyRateKey, String(dailyRate + 1), { expirationTtl: 90000 }); // 25hr
 
 	// Write to AE for error tracking metrics
 	try {
@@ -179,14 +197,15 @@ function extractErrorInfo(event: TraceItem): ErrorInfo {
 async function processSoftErrors(
 	event: TraceItem,
 	env: MonitorWorkerEnv,
-	scriptName: string
+	scriptName: string,
+	batchSeen: Set<string>
 ): Promise<void> {
 	const logs = event.logs ?? [];
 
 	for (const log of logs) {
 		if (log.level === 'error') {
 			const msg = log.message.map(String).join(' ').slice(0, 500);
-			await processLogEntry(env, scriptName, 'soft_error', msg);
+			await processLogEntry(env, scriptName, 'soft_error', msg, batchSeen);
 		} else if (log.level === 'warn') {
 			const msg = log.message.map(String).join(' ').slice(0, 500);
 			await storeWarningForDigest(env, scriptName, msg);
@@ -199,11 +218,20 @@ async function processLogEntry(
 	env: MonitorWorkerEnv,
 	scriptName: string,
 	outcome: string,
-	message: string
+	message: string,
+	batchSeen: Set<string>
 ): Promise<void> {
 	const priority = PRIORITY_MAP[outcome] ?? 'P3';
 	const fingerprint = computeFingerprint(scriptName, outcome, message);
-	const isTransient = matchTransientPattern(message, outcome);
+
+	// Batch-level dedup (#99)
+	if (batchSeen.has(fingerprint)) {
+		console.log(`[cf-monitor:tail] Batch dedup: ${scriptName}:${outcome} fp=${fingerprint}`);
+		return;
+	}
+	batchSeen.add(fingerprint);
+
+	const isTransient = matchTransientPattern(message, outcome, env._customTransientPatterns);
 
 	// Dedup: check existing fingerprint
 	const existingUrl = await env.CF_MONITOR_KV.get(`${KV.ERR_FINGERPRINT}${fingerprint}`);
@@ -218,6 +246,26 @@ async function processLogEntry(
 	if (currentRate >= MAX_ISSUES_PER_SCRIPT_PER_HOUR) {
 		console.log(`[cf-monitor:tail] Rate limit: ${scriptName} at ${currentRate}/${MAX_ISSUES_PER_SCRIPT_PER_HOUR}/hr`);
 		return;
+	}
+
+	// Daily cap (#92)
+	const dailyRateKey = `${KV.ERR_RATE}${scriptName}:daily:${currentDate()}`;
+	const dailyRate = parseInt(await env.CF_MONITOR_KV.get(dailyRateKey) ?? '0', 10);
+	if (dailyRate >= MAX_ISSUES_PER_SCRIPT_PER_DAY) {
+		console.log(`[cf-monitor:tail] Daily cap: ${scriptName} at ${dailyRate}/${MAX_ISSUES_PER_SCRIPT_PER_DAY}/day`);
+		return;
+	}
+
+	// Transient dedup: one issue per pattern per day for soft errors (#99)
+	if (isTransient) {
+		const patternName = getTransientPatternName(message, outcome, env._customTransientPatterns) ?? 'unknown';
+		const transientKey = `${KV.ERR_TRANSIENT}${scriptName}:soft_error:${patternName}:${currentDate()}`;
+		const existing = await env.CF_MONITOR_KV.get(transientKey);
+		if (existing) {
+			console.log(`[cf-monitor:tail] Transient dedup: ${scriptName}:soft_error:${patternName} already reported today`);
+			return;
+		}
+		await env.CF_MONITOR_KV.put(transientKey, '1', { expirationTtl: 90000 }); // 25hr
 	}
 
 	// Lock
@@ -257,6 +305,7 @@ async function processLogEntry(
 	}
 
 	await env.CF_MONITOR_KV.put(rateLimitKey, String(currentRate + 1), { expirationTtl: 7200 });
+	await env.CF_MONITOR_KV.put(dailyRateKey, String(dailyRate + 1), { expirationTtl: 90000 }); // 25hr
 
 	// AE metric
 	try {

--- a/tests/worker/crons/collect-account-usage.test.ts
+++ b/tests/worker/crons/collect-account-usage.test.ts
@@ -41,7 +41,7 @@ describe('collectAccountUsage', () => {
 		vi.spyOn(globalThis, 'fetch')
 			// Core services — 4 separate queries (Workers, D1, KV, R2)
 			.mockResolvedValueOnce(graphqlResponse({
-				workersInvocationsAdaptive: [{ sum: { requests: 1000, cpuTime: 5000 } }],
+				workersInvocationsAdaptive: [{ sum: { requests: 1000 }, quantiles: { cpuTimeP50: 5000 } }],
 			}))
 			.mockResolvedValueOnce(graphqlResponse({
 				d1AnalyticsAdaptiveGroups: [{ sum: { rowsRead: 50000, rowsWritten: 1000 } }],
@@ -74,7 +74,7 @@ describe('collectAccountUsage', () => {
 		const putCall = (env.CF_MONITOR_KV.put as ReturnType<typeof vi.fn>).mock.calls[0];
 		const snapshot = JSON.parse(putCall[1]);
 		expect(snapshot.disclaimer).toContain('Not authoritative');
-		expect(snapshot.services.workers).toEqual({ requests: 1000, cpuMs: 5 });
+		expect(snapshot.services.workers).toEqual({ requests: 1000, cpuMs: 5000 });
 		expect(snapshot.services.d1).toEqual({ rowsRead: 50000, rowsWritten: 1000 });
 		expect(snapshot.services.kv).toEqual({ reads: 3000, writes: 100, deletes: 2, lists: 5 });
 		expect(snapshot.services.durableObjects).toEqual({ requests: 200, storedBytes: 0 });
@@ -85,7 +85,7 @@ describe('collectAccountUsage', () => {
 		vi.spyOn(globalThis, 'fetch')
 			// Workers succeeds
 			.mockResolvedValueOnce(graphqlResponse({
-				workersInvocationsAdaptive: [{ sum: { requests: 500, cpuTime: 1000 } }],
+				workersInvocationsAdaptive: [{ sum: { requests: 500 }, quantiles: { cpuTimeP50: 1000 } }],
 			}))
 			// D1 fails
 			.mockResolvedValueOnce(new Response('Internal Server Error', { status: 500 }))
@@ -102,7 +102,7 @@ describe('collectAccountUsage', () => {
 		expect(env.CF_MONITOR_KV.put).toHaveBeenCalled();
 		const putCall = (env.CF_MONITOR_KV.put as ReturnType<typeof vi.fn>).mock.calls[0];
 		const snapshot = JSON.parse(putCall[1]);
-		expect(snapshot.services.workers).toEqual({ requests: 500, cpuMs: 1 });
+		expect(snapshot.services.workers).toEqual({ requests: 500, cpuMs: 500 });
 	});
 
 	it('handles empty results for unused services', async () => {
@@ -128,8 +128,8 @@ describe('collectAccountUsage', () => {
 			// Workers with multiple entries
 			.mockResolvedValueOnce(graphqlResponse({
 				workersInvocationsAdaptive: [
-					{ sum: { requests: 300, cpuTime: 1000 } },
-					{ sum: { requests: 700, cpuTime: 2000 } },
+					{ sum: { requests: 300 }, quantiles: { cpuTimeP50: 1000 } },
+					{ sum: { requests: 700 }, quantiles: { cpuTimeP50: 2000 } },
 				],
 			}))
 			// D1, KV, R2 empty
@@ -143,6 +143,6 @@ describe('collectAccountUsage', () => {
 
 		const putCall = (env.CF_MONITOR_KV.put as ReturnType<typeof vi.fn>).mock.calls[0];
 		const snapshot = JSON.parse(putCall[1]);
-		expect(snapshot.services.workers).toEqual({ requests: 1000, cpuMs: 3 });
+		expect(snapshot.services.workers).toEqual({ requests: 1000, cpuMs: 1700 });
 	});
 });

--- a/tests/worker/errors/fingerprint.test.ts
+++ b/tests/worker/errors/fingerprint.test.ts
@@ -32,14 +32,32 @@ describe('computeFingerprint', () => {
 		expect(a).toBe(b);
 	});
 
-	it('normalises timestamps to <TS>', () => {
-		// Numeric ID normalisation (\b\d{4,}\b) runs first, replacing the year.
-		// The remaining timestamp fragment is identical for same date+time, so
-		// messages differing only in year still produce the same fingerprint.
+	it('normalises timestamps to <TS> (#92 — regex ordering fix)', () => {
+		// Timestamp regex now runs BEFORE numeric ID regex,
+		// so full ISO timestamps are replaced as a unit.
 		const a = computeFingerprint('w', 'exception', 'Error at 2025-03-20T14:30:00Z in handler');
-		const b = computeFingerprint('w', 'exception', 'Error at 2026-03-20T14:30:00Z in handler');
-		// Both normalise: year → <N>, remaining fragment identical
+		const b = computeFingerprint('w', 'exception', 'Error at 2026-04-01T09:00:00Z in handler');
 		expect(a).toBe(b);
+	});
+
+	it('normalises timestamps with different times', () => {
+		const a = computeFingerprint('w', 'exception', 'Failed at 2026-04-03T10:30:00.123Z');
+		const b = computeFingerprint('w', 'exception', 'Failed at 2026-04-03T22:15:45.999Z');
+		expect(a).toBe(b);
+	});
+
+	it('normalises short hex IDs (8+ chars) — catches correlationIds (#92)', () => {
+		const a = computeFingerprint('w', 'exception', 'Error in request a1b2c3d4 failed');
+		const b = computeFingerprint('w', 'exception', 'Error in request f9e8d7c6 failed');
+		expect(a).toBe(b);
+	});
+
+	it('does not normalise short non-hex strings', () => {
+		// "handler" contains only [a-f] + non-hex chars — word boundary check prevents false matches
+		const a = computeFingerprint('w', 'exception', 'Error in module xyz123');
+		const b = computeFingerprint('w', 'exception', 'Error in module abc456');
+		// These differ because they're not pure hex
+		expect(a).not.toBe(b);
 	});
 
 	it('normalises IP addresses', () => {
@@ -51,5 +69,37 @@ describe('computeFingerprint', () => {
 	it('returns 8-char hex string', () => {
 		const fp = computeFingerprint('w', 'exception', 'test');
 		expect(fp).toMatch(/^[0-9a-f]{8}$/);
+	});
+
+	it('extracts message field from JSON structured logs (#92)', () => {
+		const jsonA = JSON.stringify({
+			level: 'error',
+			message: 'AI Gateway request failed after all retries',
+			timestamp: '2026-04-02T00:00:52.953Z',
+			duration_ms: 9513,
+			metadata: { totalAttempts: 4, correlationId: '83c4fec5-0f3e-4bdf-9abc-123456789012' },
+		});
+		const jsonB = JSON.stringify({
+			level: 'error',
+			message: 'AI Gateway request failed after all retries',
+			timestamp: '2026-04-03T12:01:55.100Z',
+			duration_ms: 3201,
+			metadata: { totalAttempts: 2, correlationId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' },
+		});
+		const a = computeFingerprint('bc', 'exception', jsonA);
+		const b = computeFingerprint('bc', 'exception', jsonB);
+		expect(a).toBe(b);
+	});
+
+	it('falls back to regex normalisation for invalid JSON', () => {
+		const truncated = '{"level":"error","message":"AI Gateway request failed","timestamp":"2026-04-02T00:00:52.953Z","duratio';
+		const fp = computeFingerprint('w', 'exception', truncated);
+		expect(fp).toMatch(/^[0-9a-f]{8}$/);
+	});
+
+	it('normalises JSON-embedded small numbers (#92)', () => {
+		const a = computeFingerprint('w', 'exception', '"totalAttempts": 4, "retry": 1}');
+		const b = computeFingerprint('w', 'exception', '"totalAttempts": 9, "retry": 3}');
+		expect(a).toBe(b);
 	});
 });

--- a/tests/worker/errors/patterns.test.ts
+++ b/tests/worker/errors/patterns.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { matchTransientPattern, getTransientPatternName } from '../../../src/worker/errors/patterns.js';
+import type { CustomTransientPattern } from '../../../src/types.js';
 
 describe('matchTransientPattern', () => {
 	it('matches rate limit errors', () => {
@@ -45,6 +46,34 @@ describe('matchTransientPattern', () => {
 		expect(matchTransientPattern('Cloudflare internal error occurred', 'exception')).toBe(true);
 	});
 
+	it('matches billing-exhausted errors (#92)', () => {
+		expect(matchTransientPattern('DeepSeek API error: 402 Insufficient Balance', 'exception')).toBe(true);
+		expect(matchTransientPattern('402 Payment Required', 'exception')).toBe(true);
+		expect(matchTransientPattern('insufficient balance on account', 'exception')).toBe(true);
+		expect(matchTransientPattern('payment required for this API', 'exception')).toBe(true);
+	});
+
+	it('matches custom patterns from cf-monitor.yaml (#92)', () => {
+		const customPatterns: CustomTransientPattern[] = [
+			{ name: 'custom-error', match: 'my-special-error|custom_failure' },
+		];
+		expect(matchTransientPattern('my-special-error occurred', 'exception', customPatterns)).toBe(true);
+		expect(matchTransientPattern('custom_failure in handler', 'exception', customPatterns)).toBe(true);
+	});
+
+	it('returns false for custom patterns when message does not match', () => {
+		const customPatterns: CustomTransientPattern[] = [
+			{ name: 'custom-error', match: 'my-special-error' },
+		];
+		expect(matchTransientPattern('NullPointerException', 'exception', customPatterns)).toBe(false);
+	});
+
+	it('works without custom patterns (backward compatible)', () => {
+		expect(matchTransientPattern('rate limit exceeded', 'exception')).toBe(true);
+		expect(matchTransientPattern('rate limit exceeded', 'exception', undefined)).toBe(true);
+		expect(matchTransientPattern('rate limit exceeded', 'exception', [])).toBe(true);
+	});
+
 	it('returns false for non-transient errors', () => {
 		expect(matchTransientPattern('NullPointerException', 'exception')).toBe(false);
 		expect(matchTransientPattern('TypeError: Cannot read properties of undefined', 'exception')).toBe(false);
@@ -63,6 +92,25 @@ describe('getTransientPatternName', () => {
 
 	it('returns correct pattern name for quota', () => {
 		expect(getTransientPatternName('quota exceeded', 'exception')).toBe('quota-exhausted');
+	});
+
+	it('returns correct pattern name for billing-exhausted (#92)', () => {
+		expect(getTransientPatternName('DeepSeek API error: 402 Insufficient Balance', 'exception')).toBe('billing-exhausted');
+	});
+
+	it('returns custom pattern name (#92)', () => {
+		const customPatterns: CustomTransientPattern[] = [
+			{ name: 'my-custom', match: 'special-error' },
+		];
+		expect(getTransientPatternName('special-error in handler', 'exception', customPatterns)).toBe('my-custom');
+	});
+
+	it('prefers built-in over custom pattern', () => {
+		const customPatterns: CustomTransientPattern[] = [
+			{ name: 'custom-timeout', match: 'timeout' },
+		];
+		// Built-in 'timeout' pattern should win
+		expect(getTransientPatternName('connection timeout', 'exception', customPatterns)).toBe('timeout');
 	});
 
 	it('returns null for non-transient errors', () => {

--- a/tests/worker/tail-handler.test.ts
+++ b/tests/worker/tail-handler.test.ts
@@ -285,3 +285,184 @@ describe('observability logging (#82)', () => {
 		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Skip non-capturable:'));
 	});
 });
+
+describe('daily issue cap (#92)', () => {
+	it('prevents more than 50 issues per script per day', async () => {
+		// Pre-seed daily counter near the limit
+		const today = new Date().toISOString().slice(0, 10);
+		await env.CF_MONITOR_KV.put(`err:rate:my-worker:daily:${today}`, '50', { expirationTtl: 90000 });
+
+		await handleTailEvents(
+			[createTraceItem({
+				exceptions: [{ name: 'Error', message: 'New unique error', timestamp: Date.now() }],
+			})],
+			env,
+			ctx
+		);
+
+		// Should NOT create a GitHub issue (daily cap reached)
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it('allows issues when daily counter is below cap', async () => {
+		const today = new Date().toISOString().slice(0, 10);
+		await env.CF_MONITOR_KV.put(`err:rate:my-worker:daily:${today}`, '49', { expirationTtl: 90000 });
+
+		await handleTailEvents(
+			[createTraceItem({
+				exceptions: [{ name: 'Error', message: 'New unique error below cap', timestamp: Date.now() }],
+			})],
+			env,
+			ctx
+		);
+
+		expect(mockFetch).toHaveBeenCalledOnce();
+	});
+
+	it('increments daily counter after issue creation', async () => {
+		await handleTailEvents([createTraceItem()], env, ctx);
+
+		const today = new Date().toISOString().slice(0, 10);
+		const count = await env.CF_MONITOR_KV.get(`err:rate:my-worker:daily:${today}`);
+		expect(count).toBe('1');
+	});
+});
+
+describe('custom transient patterns (#92)', () => {
+	it('uses custom transient patterns from env for daily dedup', async () => {
+		env._customTransientPatterns = [
+			{ name: 'custom-billing', match: 'insufficient.*balance' },
+		];
+
+		// First event with matching message should create an issue
+		await handleTailEvents(
+			[createTraceItem({
+				exceptions: [{ name: 'Error', message: 'DeepSeek: 402 Insufficient Balance', timestamp: Date.now() }],
+			})],
+			env,
+			ctx
+		);
+		expect(mockFetch).toHaveBeenCalledOnce();
+
+		mockFetch.mockClear();
+
+		// Second event same day — transient dedup should prevent duplicate
+		await handleTailEvents(
+			[createTraceItem({
+				scriptName: 'my-worker',
+				exceptions: [{ name: 'Error', message: 'DeepSeek: 402 Insufficient Balance again', timestamp: Date.now() }],
+			})],
+			env,
+			ctx
+		);
+
+		// The built-in billing-exhausted pattern or custom pattern catches it,
+		// and transient dedup key prevents the second issue
+		// (First event already set the transient key)
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+});
+
+describe('soft error transient dedup (#99)', () => {
+	it('deduplicates transient soft errors to one issue per pattern per day', async () => {
+		// First soft error with rate limit message — should create issue
+		const event1 = createTraceItem({
+			outcome: 'ok',
+			exceptions: [],
+			logs: [
+				{ level: 'error', message: ['429 Too Many Requests from API'], timestamp: Date.now() },
+			],
+		});
+		await handleTailEvents([event1], env, ctx);
+		expect(mockFetch).toHaveBeenCalledOnce();
+
+		mockFetch.mockClear();
+
+		// Second soft error same pattern same day — transient dedup should skip
+		const event2 = createTraceItem({
+			outcome: 'ok',
+			exceptions: [],
+			logs: [
+				{ level: 'error', message: ['429 Too Many Requests again'], timestamp: Date.now() },
+			],
+		});
+		await handleTailEvents([event2], env, ctx);
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it('allows non-transient soft errors through', async () => {
+		const event = createTraceItem({
+			outcome: 'ok',
+			exceptions: [],
+			logs: [
+				{ level: 'error', message: ['TypeError: Cannot read property of undefined'], timestamp: Date.now() },
+			],
+		});
+		await handleTailEvents([event], env, ctx);
+		expect(mockFetch).toHaveBeenCalledOnce();
+	});
+});
+
+describe('batch-level dedup (#99 — #1228 burst)', () => {
+	it('deduplicates identical errors within the same tail batch', async () => {
+		const events = [
+			createTraceItem({
+				scriptName: 'bc-worker',
+				exceptions: [{ name: 'Error', message: 'Gemini 503 Service Unavailable', timestamp: Date.now() }],
+			}),
+			createTraceItem({
+				scriptName: 'bc-worker',
+				exceptions: [{ name: 'Error', message: 'Gemini 503 Service Unavailable', timestamp: Date.now() }],
+			}),
+			createTraceItem({
+				scriptName: 'bc-worker',
+				exceptions: [{ name: 'Error', message: 'Gemini 503 Service Unavailable', timestamp: Date.now() }],
+			}),
+			createTraceItem({
+				scriptName: 'bc-worker',
+				exceptions: [{ name: 'Error', message: 'Gemini 503 Service Unavailable', timestamp: Date.now() }],
+			}),
+		];
+
+		await handleTailEvents(events, env, ctx);
+
+		// Only 1 issue should be created despite 4 identical errors in the batch
+		expect(mockFetch).toHaveBeenCalledOnce();
+	});
+
+	it('allows different errors in the same batch through', async () => {
+		const events = [
+			createTraceItem({
+				scriptName: 'bc-worker',
+				exceptions: [{ name: 'Error', message: 'Gemini 503 Service Unavailable', timestamp: Date.now() }],
+			}),
+			createTraceItem({
+				scriptName: 'bc-worker',
+				exceptions: [{ name: 'TypeError', message: 'Cannot read property of undefined', timestamp: Date.now() }],
+			}),
+		];
+
+		await handleTailEvents(events, env, ctx);
+
+		// 2 different errors → 2 issues
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it('deduplicates identical soft errors within the same batch', async () => {
+		const events = [
+			createTraceItem({
+				outcome: 'ok',
+				exceptions: [],
+				logs: [
+					{ level: 'error', message: ['Database connection failed'], timestamp: Date.now() },
+					{ level: 'error', message: ['Database connection failed'], timestamp: Date.now() },
+				],
+			}),
+		];
+
+		await handleTailEvents(events, env, ctx);
+
+		// Only 1 issue for the duplicate soft errors
+		expect(mockFetch).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes 8 issues reported by Brand Copilot (#99 umbrella) that caused 90+ duplicate GitHub issues/day and 14 silent GraphQL errors/day.

### Fixes
- **#92** — JSON message extraction in fingerprint normaliser (structured logs with variable metadata)
- **#93** — `cpuTime` → `quantiles { cpuTimeP50 }` (CF removed cpuTime from sum selection)
- **#94** — Regex ordering: timestamps before numeric IDs (prevents year stripping)
- **#95** — Hex ID threshold 24 → 8 chars (catches short correlationIds)
- **#96** — Custom `transient_patterns` from cf-monitor.yaml now wired into matcher
- **#97** — Built-in `billing-exhausted` transient pattern (402, insufficient balance)
- **#98** — Daily issue cap of 50/script/day (prevents sustained floods)
- **#99** — Soft error transient dedup + in-memory batch-level dedup (eliminates same-batch race conditions)

### Dedup architecture (6 layers)
1. **Batch Set** (in-memory) — zero-latency same-batch dedup
2. **Fingerprint KV** — 90-day dedup
3. **Hourly rate** — 10/script/hour
4. **Daily cap** — 50/script/day
5. **Transient dedup** — 1 issue/pattern/day (hard + soft errors)
6. **Lock** — 60s concurrent-invocation guard

### Docs
- CHANGELOG.md with full v0.3.8 entries
- Updated all 13 doc files (configuration, error-collection, cost-spike, budgets guides)
- Removed transient_patterns stub warning (now implemented)
- Updated version across package.json, CLAUDE.md, AGENTS.md, llms.txt, schema, bug template

## Test plan
- [x] 338 unit tests pass (22 new)
- [x] TypeScript typecheck clean
- [ ] CI pipeline passes
- [ ] Integration tests (post-merge, via workflow_dispatch)

Closes #92, #93, #94, #95, #96, #97, #98, #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)