### PR TITLE
docs(context): teach future sessions about docs/faq/index.md

### DIFF
--- a/.claude/rules/docs-faq.md
+++ b/.claude/rules/docs-faq.md
@@ -1,0 +1,70 @@
+# `docs/faq/index.md` — Marketing-Site FAQPage Source
+
+`docs/faq/index.md` is **not an ordinary doc**. It is the upstream source for the FAQPage JSON-LD schema rendered at <https://littlebearapps.com/help/cf-monitor/faq/>. The file was added in PR #104 (closes #103) and is consumed by the `littlebearapps/littlebearapps.com` repo's docs-sync pipeline.
+
+## Why it exists
+
+- **AI-citation surface**: ChatGPT, Perplexity, and Google AI Overviews preferentially cite content with `FAQPage` JSON-LD. Without this file, cf-monitor has no dedicated FAQ on the marketing site and relies on incidental section-level detection.
+- **Google FAQ-rich SERP snippets**: Google occasionally renders FAQ-rich results from FAQPage schema.
+- **Schema is already wired**: the marketing site auto-extracts question-shaped H2s and emits FAQPage. The schema fires automatically as long as this file (a) exists at this path, and (b) has ≥7 question-shaped H2s.
+
+## Do NOT
+
+- **Do not delete or rename** `docs/faq/index.md` or the `docs/faq/` directory. The marketing-site sync (`littlebearapps/littlebearapps.com`, `scripts/docs-sync.config.ts`, `cf-monitor` entry, `source: 'docs/faq'`) **hard-fails the build** if the upstream source is missing. Removing the file breaks the marketing site, not just cf-monitor.
+- **Do not move it** to `docs/faq.md` (single-file form) or another path without a coordinated PR in `littlebearapps.com` updating `docs-sync.config.ts`. The site-side PR must land **before** the upstream move, or the sync fails.
+- **Do not strip the frontmatter**. The sync pipeline injects `category: faq`, `tool: cf-monitor`, `pubDate`, and other site fields automatically — but it relies on `title` + `description` being present in the upstream file. Keep both.
+- **Do not add a `category:` or `tool:` field** to the frontmatter yourself — the sync injects them. A duplicate field will conflict.
+
+## When to update
+
+Update `docs/faq/index.md` whenever cf-monitor changes any of the user-facing surfaces the FAQ describes. Concrete triggers:
+
+| Change | FAQ section to revisit |
+|--------|------------------------|
+| New CLI command, renamed command, or changed install flow | "How do I install cf-monitor?" |
+| Changed required CF API token scopes, GitHub PAT scopes, or added/removed secrets | "What Cloudflare API token permissions does cf-monitor need?" |
+| New tracked binding type, new KV prefix, changed AE retention | "What data does cf-monitor collect, and where does it go?" |
+| Change to fail-open behaviour or per-invocation limits | "What happens if cf-monitor itself fails?" |
+| AE/KV/Worker pricing-model changes that affect cf-monitor's own footprint | "Does cf-monitor cost anything to run?" |
+| Plan-detection behaviour change (subscriptions API, fallback semantics, allowance tables) | "How does cf-monitor know whether I'm on Workers Free or Paid?" |
+| New CB reset semantics, new admin endpoints for CB control | "Why isn't my circuit breaker resetting?" |
+| New alert channel, removed alert type, or change to GitHub/Slack secrets | "Can cf-monitor create GitHub issues and Slack alerts for me?" |
+| AI feature graduating from stub to real, or new AI feature added | "Are the AI features ... ready to use?" |
+| Changed update procedure (e.g. new migration step), changed uninstall procedure | "How do I update cf-monitor, and how do I uninstall it?" |
+
+If a change doesn't fit any existing question, consider adding a new Q. Don't pad with marginal questions just to add coverage — every Q should answer something a real user has asked or would ask.
+
+## How to update
+
+1. **Edit in place** — the file is canonical. Don't fork it into a separate "draft FAQ" elsewhere.
+2. **Keep answers sourced from existing docs** (`README.md`, `docs/getting-started.md`, `docs/troubleshooting.md`, `docs/security.md`, `docs/guides/*`). Cross-link with relative paths (`../guides/plan-detection.md`) rather than restating long sections inline. The FAQ is a fast-look-up; the linked docs are the authoritative source.
+3. **Match the existing voice**: informal, developer-first, code examples, opinionated. Use `> **Note:**` blockquotes for caveats. Australian English where natural (*realise, colour, behaviour, defence*) — leave existing US-spelt API/CLI names alone.
+4. **Preserve frontmatter shape**:
+   ```yaml
+   ---
+   title: "cf-monitor — Frequently Asked Questions"
+   description: "Common questions about cf-monitor: ..."
+   ---
+   ```
+   Only `title` + `description`. Update `description` if the question coverage shifts noticeably.
+5. **Maintain ≥7 question-shaped H2s** (end with `?` or start with How / What / Why / When / Where / Can / Do / Does / Is / Are / Should / Will). The FAQPage extractor needs this shape to emit valid JSON-LD. Below 7, the schema fires anyway (≥2 minimum) but the `category: faq` frontmatter alone guarantees emission. Below 2, no schema.
+6. **No placeholders** (`TODO`, `[placeholder]`, `XXX`, `FIXME`). The marketing-site reviewer treats the file as production content.
+7. **Verify before committing**:
+   ```bash
+   grep -c '^## ' docs/faq/index.md             # should be ≥7
+   grep -nE 'TODO|XXX|FIXME' docs/faq/index.md  # should return nothing
+   # Spot-check that every relative link resolves (../getting-started.md, etc.)
+   ```
+
+## Where it shows up downstream
+
+- **Source of truth** (this repo): `docs/faq/index.md` on `main`.
+- **Sync config** (other repo): `littlebearapps/littlebearapps.com`, `scripts/docs-sync.config.ts`, `cf-monitor` entry includes `{ source: 'docs/faq', category: 'faq' }`. **Do not modify the upstream filename without a coordinated PR there.**
+- **Public URL**: `https://littlebearapps.com/help/cf-monitor/faq/` (or whatever slug the sync produces — single-file directories typically map to the parent slug).
+- **Schema marker** (post-deploy verification): the rendered page contains `<script type="application/ld+json">` with `"@type":"FAQPage"`.
+
+## Quick reference
+
+- **Read the file**: `docs/faq/index.md` (~170 lines, ~1900 words).
+- **In-repo discoverability**: linked from `docs/README.md` under "Reference".
+- **Change history**: PR #104 (initial scaffold, closes #103). Future changes should reference the relevant cf-monitor change PR/issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,18 @@ cf-monitor/
       commands/           # 9 commands: init, deploy, wire, status, coverage, secret, config-sync, upgrade, migrate, usage
   tests/                  # 338 unit tests + 53 integration tests (10 files)
   worker/                 # Pre-built entry for wrangler deploy
-  docs/                   # 20 documentation files (getting-started, configuration, security, troubleshooting + 10 guides + 3 how-to)
+  docs/
+    README.md             # Documentation index
+    getting-started.md, configuration.md, security.md, troubleshooting.md
+    guides/               # 11 task-oriented guides
+    how-to/               # 3 step-by-step how-tos
+    faq/index.md          # Marketing-site FAQPage source — DO NOT delete or rename
 ```
+
+## Documentation Policy
+
+- **`docs/faq/index.md` is sync-managed.** It is the upstream source for the FAQPage JSON-LD schema rendered at <https://littlebearapps.com/help/cf-monitor/faq/>. The marketing site's docs-sync pipeline (`littlebearapps/littlebearapps.com`, `scripts/docs-sync.config.ts`) hard-fails the build if the source is missing or moved. **Do not delete, rename, or relocate** without a coordinated PR in the marketing-site repo.
+- **Update the FAQ when user-facing surfaces change**: install steps, required token scopes, secrets, data collection, fail-open behaviour, costs, plan detection, CB reset semantics, alert channels, AI feature status, update/uninstall procedure. Keep answers terse and link to the authoritative source doc rather than restating it. Maintain ≥7 question-shaped H2s. See `.claude/rules/docs-faq.md` for the full editorial rules.
 
 ## Key Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,14 @@ cf-monitor/
 │
 ├── vitest.integration.config.ts  # Integration test config (globalSetup, 120s timeout)
 │
+├── docs/
+│   ├── README.md             # Documentation index
+│   ├── getting-started.md, configuration.md, security.md, troubleshooting.md
+│   ├── guides/               # 11 task-oriented guides
+│   ├── how-to/               # 3 step-by-step how-tos
+│   └── faq/index.md          # Marketing-site FAQPage source — DO NOT delete or rename
+│                             # See .claude/rules/docs-faq.md for editorial rules
+│
 └── tests/                    # 290 unit tests + 53 integration tests
     ├── helpers/               # Mock KV, AE, env, request factories
     ├── sdk/                   # monitor, proxy, metrics, detection, circuit-breaker
@@ -116,6 +124,20 @@ cf-monitor/
         ├── test-consumer.ts   # 13-route consumer worker for testing
         └── 01-10*.test.ts     # Sequential: health, SDK, CB, telemetry, webhooks, budgets, crons, errors, dry-run, proxy-tracking
 ```
+
+---
+
+## Documentation Policy
+
+`docs/faq/index.md` is **sync-managed** — it's the upstream source for the FAQPage JSON-LD schema rendered at <https://littlebearapps.com/help/cf-monitor/faq/> via the marketing-site docs-sync pipeline (`littlebearapps/littlebearapps.com`, `scripts/docs-sync.config.ts`, `cf-monitor` entry, `source: 'docs/faq'`).
+
+- **Do not delete, rename, or move** the file or its directory — the site sync hard-fails the build on a missing source. Any path change requires a coordinated PR in the marketing-site repo to land **first**.
+- **Frontmatter is `title` + `description` only.** The sync injects `category: faq`, `tool: cf-monitor`, and dates. Don't duplicate those fields.
+- **Update when user-facing surfaces change**: install steps, required CF/GitHub token scopes, secrets, data collection, fail-open semantics, costs, plan detection, CB reset, alerts, AI feature status, update/uninstall procedure. Keep answers terse and cross-link to authoritative source docs rather than restating them.
+- **Maintain ≥7 question-shaped H2s.** Below 2 the FAQPage schema doesn't fire.
+- **Match existing voice**: informal, code-heavy, AU English where natural. No placeholders, no `TODO`/`FIXME`.
+
+Full editorial rules + verification commands: **`.claude/rules/docs-faq.md`**.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,7 @@ cf-monitor wraps Cloudflare Workers with a single `monitor()` call, tracks every
 - [Configuration Reference](https://github.com/littlebearapps/cf-monitor/blob/main/docs/configuration.md): All cf-monitor.yaml and MonitorConfig SDK options
 - [Security](https://github.com/littlebearapps/cf-monitor/blob/main/docs/security.md): Admin auth, secrets, threat model, data exposure
 - [Troubleshooting](https://github.com/littlebearapps/cf-monitor/blob/main/docs/troubleshooting.md): 16 common issues with solutions
+- [FAQ](https://github.com/littlebearapps/cf-monitor/blob/main/docs/faq/index.md): Installation, permissions, costs, fail-open behaviour, alerts, AI feature status, updates (also published at https://littlebearapps.com/help/cf-monitor/faq/ with FAQPage JSON-LD)
 - [Changelog](https://github.com/littlebearapps/cf-monitor/blob/main/CHANGELOG.md): Version history v0.1.0 to v0.3.8
 - [Contributing](https://github.com/littlebearapps/cf-monitor/blob/main/CONTRIBUTING.md): Development setup and conventions
 


### PR DESCRIPTION
Follow-up to #103 / #104.

## Summary

Teaches future Claude/agentic sessions in this repo what `docs/faq/index.md` is for, that it can't be deleted, and when to update it.

After PR #104 landed the FAQ scaffold, the next agent walking into this repo wouldn't know:
- The file is the upstream source for the marketing-site FAQPage JSON-LD schema.
- Deleting or moving it hard-fails the `littlebearapps.com` build.
- It needs maintenance whenever cf-monitor's user-facing surfaces change (install, permissions, costs, alerts, AI status, etc.).

This PR closes that knowledge gap.

## Changes

| File | Change |
|------|--------|
| `.claude/rules/docs-faq.md` | **NEW** — canonical, focused rule (~70 lines): purpose, do-nots, update triggers per FAQ section, editorial style, verification commands, downstream sync details |
| `CLAUDE.md` | Added `docs/` to Repository Structure tree; new "Documentation Policy" subsection after Repository Structure pointing at the rule |
| `AGENTS.md` | Expanded `docs/` listing to surface `docs/faq/index.md`; new "Documentation Policy" section pointing at the rule |
| `llms.txt` | Added FAQ URL to the Documentation list with a note that it's also published at `https://littlebearapps.com/help/cf-monitor/faq/` with FAQPage JSON-LD |

No changes to `src/` or `tests/`.

## Why a dedicated rule file

The cf-monitor repo follows the project's own context-quality convention (see `.claude/rules/context-quality.md`): AGENTS.md is canonical, bridges (CLAUDE.md, llms.txt) point at it. A dedicated `.claude/rules/docs-faq.md` keeps the detailed editorial rules in one place, lets bridges stay terse, and is automatically loaded by Claude Code sessions in this repo.

## Test plan

- [ ] CI: lint, typecheck, and unit tests pass (no source changes — should be green automatically).
- [ ] Reviewer reads `.claude/rules/docs-faq.md` and confirms the editorial rules + update triggers match the team's intent.
- [ ] Reviewer eyeballs the bridge updates (CLAUDE.md, AGENTS.md, llms.txt) for tone match with surrounding content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)