### PR TITLE
chore: v0.3.9 — revert to NPM_TOKEN publish (OIDC debug pending)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,16 @@ jobs:
         run: npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --allowed-schemes "https:"
 
       - name: Publish to npm
-        # Authenticates via npm Trusted Publisher (OIDC) using id-token: write permission above.
-        # Configured on npmjs.com → @littlebearapps/cf-monitor → Trusted Publishers → GitHub Actions.
-        # --provenance attaches SLSA build provenance attestation visible on the npm package page.
-        # NPM_TOKEN env var intentionally absent; remove the NPM_TOKEN repo secret once the first
-        # OIDC publish has succeeded.
-        run: npm publish --access public --provenance
+        # Token-based publish via NPM_TOKEN repo secret.
+        # OIDC Trusted Publisher was attempted for v0.3.9 — provenance signing worked but
+        # npm registry returned 404 on PUT despite the trusted-publisher fields matching the
+        # OIDC token claims (org=littlebearapps, repo=cf-monitor, workflow=release.yml,
+        # env=empty). Reverted to token publish to unblock release; OIDC investigation
+        # tracked separately. Re-enable by restoring `--provenance` and removing
+        # NODE_AUTH_TOKEN once npm-side mismatch is identified and fixed.
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Extract release notes from CHANGELOG
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ All notable changes to cf-monitor are documented here. This project follows [Kee
 - `extractErrorInfo()` now checks exceptions before error logs (exceptions have stack traces)
 - `processLogEntry()` accepts the full `TraceItem` event to extract trace context for soft errors
 - Renamed `docs/faq/index.md` → `docs/faq/faq.md` (#110). Marketing-site FAQ now publishes at the cleaner URL `https://littlebearapps.com/help/cf-monitor/faq/` instead of `/index/`. Sync uses `source: 'docs/faq'` (directory), so the marketing site auto-picks the new filename on next build.
-- Release workflow now publishes to npm via **OIDC Trusted Publisher** (configured on npmjs.com) with `--provenance`. Removes dependency on a long-lived `NPM_TOKEN` secret and attaches SLSA build provenance to each published version. `NPM_TOKEN` repo secret retained as a fallback until the first OIDC publish succeeds.
 
 ## [0.3.8] - 2026-04-15
 


### PR DESCRIPTION
## Summary

Reverts the OIDC trusted publisher portion of the v0.3.9 release. The FAQ rename (#110) from PR #111 stays — only the npm publish auth method changes.

### Why

The OIDC trusted publisher publish failed twice for v0.3.9 (workflow runs #26392236977 and #26434691686) with `HTTP 404 - PUT @littlebearapps/cf-monitor` even though provenance signing succeeded both times (sigstore log entries 1632194556, 1632211852). User verified the trusted-publisher fields on npmjs.com match exactly (`littlebearapps` / `cf-monitor` / `release.yml` / empty env). Root cause needs investigation that we don't want to block shipping v0.3.9 on.

### What changes

- `.github/workflows/release.yml` — Publish step: remove `--provenance` flag (it requires OIDC); restore `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` block. Keep `id-token: write` permission for an eventual OIDC retry. Comment block updated to document why.
- `CHANGELOG.md` — drop the OIDC bullet from v0.3.9 "Changed" section (it isn't actually shipping in this version). FAQ rename bullet stays.

### Out of band

- GH repo secret `NPM_TOKEN` already updated to the freshly rotated value (BWS revision `2026-05-26T04:11:48Z`). Verified locally as `nathanschram`.
- After this PR merges, retag v0.3.9 at the new main HEAD to trigger `release.yml`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 365/365 passing
- [ ] After merge: `gh run watch` release.yml passes with `NODE_AUTH_TOKEN` publish.
- [ ] `npm view @littlebearapps/cf-monitor version` → `0.3.9`
- [ ] `gh release view v0.3.9` exists

## Follow-up

Will open a tracking issue for the OIDC trusted publisher 404 mystery so it doesn't get lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)