### PR TITLE
chore: v0.3.9 — restore OIDC + provenance publish (Trusted Publisher recreated)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,16 +58,13 @@ jobs:
         run: npx lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --allowed-schemes "https:"
 
       - name: Publish to npm
-        # Token-based publish via NPM_TOKEN repo secret.
-        # OIDC Trusted Publisher was attempted for v0.3.9 — provenance signing worked but
-        # npm registry returned 404 on PUT despite the trusted-publisher fields matching the
-        # OIDC token claims (org=littlebearapps, repo=cf-monitor, workflow=release.yml,
-        # env=empty). Reverted to token publish to unblock release; OIDC investigation
-        # tracked separately. Re-enable by restoring `--provenance` and removing
-        # NODE_AUTH_TOKEN once npm-side mismatch is identified and fixed.
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # Authenticates via npm Trusted Publisher (OIDC) using the id-token: write permission above.
+        # Trusted Publisher entry on npmjs.com for @littlebearapps/cf-monitor delegates
+        # `npm publish` permission to this workflow (org=littlebearapps, repo=cf-monitor,
+        # workflow=release.yml, env=empty). --provenance attaches SLSA build provenance
+        # attestation visible as a verified-build badge on the npm package page.
+        # NPM_TOKEN repo secret can be revoked once the first OIDC publish succeeds.
+        run: npm publish --access public --provenance
 
       - name: Extract release notes from CHANGELOG
         run: |


### PR DESCRIPTION
## Summary

Re-enables OIDC Trusted Publisher + SLSA provenance on the npm publish step. User recreated the Trusted Publisher entry on npmjs.com — the new entry shows **"Permissions: npm publish"** explicitly, which is the publish-permission delegation that was missing in earlier sessions. That delegation is what unblocks publishing.

## Changes

`.github/workflows/release.yml` publish step:
- Add `--provenance` flag
- Remove `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` block (OIDC replaces token auth)
- Comment refreshed

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 365/365 passing
- [ ] After merge: re-tag v0.3.9 at new HEAD, watch `release.yml`. Expect OIDC publish to succeed, package on npm with provenance badge.

## Cleanup once green

- Resolve #113 (OIDC investigation)
- Delete #110 (FAQ rename, shipped via #111)
- Revoke `NPM_TOKEN` on npmjs.com + remove repo secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)